### PR TITLE
Mercenary Company Conditional

### DIFF
--- a/Difficulty and AI changes Full version/common/mercenary_companies/00_mercenaries.txt
+++ b/Difficulty and AI changes Full version/common/mercenary_companies/00_mercenaries.txt
@@ -1,0 +1,1947 @@
+# Lombard Free Company
+merc_lombard_free_company = {
+    regiments_per_development = 0.04
+    home_province = 4728 # Pavia
+	cavalry_weight = 0.2
+	cavalry_cap = 4
+	sprites = { dlc056_mlo_sprite_pack sav_base_sprite_pack westerngfx_sprite_pack }
+    trigger = {
+		custom_trigger_tooltip = {
+			tooltip = italian_wars_flag_tt
+			has_global_flag = italian_wars_global_flag
+		}
+		religion_group = christian
+		capital_scope = {
+			continent = europe
+		}
+		OR = {
+			AND = {
+				NOT = {
+					capital_scope = {
+						region = italy_region
+					}
+				}
+				any_country = {
+					war_with = root
+					capital_scope = {
+						region = italy_region
+					}
+				}
+			}
+			capital_scope = {
+				region = italy_region
+			}
+		}
+	}
+	modifier = { 
+		infantry_power = 0.05
+	}
+}
+
+# Tuscan Free Company
+merc_tuscan_free_company = {
+    regiments_per_development = 0.04
+    home_province = 2980 # Lucca
+	cavalry_weight = 0.2
+	cavalry_cap = 4
+	sprites = { dlc056_lan_sprite_pack sav_base_sprite_pack westerngfx_sprite_pack }
+   trigger = {
+		custom_trigger_tooltip = {
+			tooltip = italian_wars_flag_tt
+			has_global_flag = italian_wars_global_flag
+		}
+		religion_group = christian
+		capital_scope = {
+			continent = europe
+		}
+		OR = {
+			AND = {
+				NOT = {
+					capital_scope = {
+						region = italy_region
+					}
+				}
+				any_country = {
+					war_with = root
+					capital_scope = {
+						region = italy_region
+					}
+				}
+			}
+			capital_scope = {
+				region = italy_region
+			}
+		}
+	}
+	modifier = { 
+		infantry_power = 0.05
+	}
+}
+
+# Black Army (Hungary)
+merc_black_army = {
+	regiments_per_development = 0.04
+	cavalry_weight = 0.2
+    artillery_weight = 0.4
+	cavalry_cap = 4
+	home_province = 153
+	sprites = { easterngfx_sprite_pack }
+	trigger = {
+		OR = {
+			has_country_modifier = hun_black_army
+			has_reform = black_army_reform
+		}
+	}
+	cost_modifier = 0.75
+	modifier = {
+		discipline = 0.05
+	}
+}
+
+# Black Army Reserves (Hungary)
+merc_black_army_2 = {
+	regiments_per_development = 0.04
+	cavalry_weight = 0.2
+    artillery_weight = 0.4
+	cavalry_cap = 4
+	home_province = 153
+	sprites = { easterngfx_sprite_pack }
+	trigger = {
+		has_reform = black_army_reform
+	}
+	cost_modifier = 0.75
+	modifier = {
+		discipline = 0.05
+	}
+}
+
+# Knights Templar
+merc_knights_templar = {
+	regiments_per_development = 0.01
+	home_province = 379
+	cavalry_weight = 0.5
+	sprites = { westerngfx_sprite_pack }
+	trigger = {
+		custom_trigger_tooltip = {
+			tooltip = templars_tt
+			has_country_flag = knights_templar_flag
+		}
+		owns = 379
+	}
+	modifier = {
+		cavalry_power = 0.15
+		shock_damage = 0.05
+	}
+	cost_modifier = 0.5
+}
+
+# Pontifical Swiss Guard
+merc_swiss_guard = {
+    regiments_per_development = 0.005
+	home_province = 166
+	sprites = { dlc029_pap_sprite_pack dlc040_pap_sprite_pack westerngfx_sprite_pack }
+    trigger = { 
+		tag = PAP
+		custom_trigger_tooltip = {
+			tooltip = swiss_guard_activated
+			has_country_flag = enable_swiss_guard
+		}
+	}
+    cost_modifier = 0.5
+	modifier = {
+		discipline = 0.025
+	}
+}
+
+# Bande Nere (Black Bands, Italy)
+merc_bande_nere = {
+    regiments_per_development = 0.05
+    home_province = 2978 # Florence
+	artillery_weight = 0.3
+	sprites = { dlc056_lan_sprite_pack sav_base_sprite_pack westerngfx_sprite_pack }
+    trigger = {
+		OR = {
+			capital_scope = { 
+				OR = {
+					region = italy_region
+					region = iberia_region
+					region = france_region
+				}
+			}
+			has_country_modifier = mercenaries_to_the_standard
+			has_country_modifier = glut_of_mercs
+		}
+		custom_trigger_tooltip = {
+			tooltip = no_new_mercs_tt
+			NOT = { has_global_flag = new_european_mercs }
+		}
+	}
+	modifier = {}
+}
+
+# Schwarze Garde (Black Bands, Germany)
+merc_schwarze_garde = {
+    regiments_per_development = 0.05
+    home_province = 61 # Dresden
+	artillery_weight = 0.3
+	sprites = { dlc028_ned_sprite_pack dlc042_ned_sprite_pack westerngfx_sprite_pack }
+    trigger = {
+		OR = {
+			capital_scope = { 
+				OR = {
+					region = south_german_region
+					region = north_german_region
+				}
+			}
+			has_country_modifier = swedish_mercenary_core
+			has_country_modifier = mercenaries_to_the_standard
+			has_country_modifier = glut_of_mercs
+		}
+		custom_trigger_tooltip = {
+			tooltip = no_new_mercs_tt
+			NOT = { has_global_flag = new_european_mercs }
+		}
+	}
+}
+
+# Doppelsoeldner (Swabia)
+merc_doppelsoeldner = {
+    regiments_per_development = 0.02
+    home_province = 70 # Stuttgart
+	artillery_weight = 0.3
+    cost_modifier = 1.25
+	sprites = { dlc061_wur_sprite_pack dlc028_wur_sprite_pack westerngfx_sprite_pack }
+    trigger = {
+		OR = {
+			capital_scope = { 
+				OR = {
+					region = south_german_region
+					region = north_german_region
+				}
+			}
+			has_country_modifier = swedish_mercenary_core
+		}
+	}
+	modifier = {
+        infantry_power = 0.1
+        discipline = 0.025
+	}
+}
+
+# Reisläufer (Switzerland)
+merc_reislaufer = {
+    regiments_per_development = 0.025
+    home_province = 165 # 
+	artillery_weight = 0.3
+	sprites = { westerngfx_sprite_pack }
+    trigger = {
+		OR = {
+			capital_scope = { 
+				OR = {
+					region = south_german_region
+					region = north_german_region
+					region = italy_region
+					region = france_region
+				}
+			}
+			has_country_modifier = swedish_mercenary_core
+			has_country_modifier = mercenaries_to_the_standard
+			has_country_modifier = glut_of_mercs
+		}
+	}
+	modifier = {
+        shock_damage_received = -0.05
+	}
+}
+
+# Hessian Jaegerkorps (Hesse, Absolutism + Revolution)
+merc_hessian_jaegerkorps = {
+    regiments_per_development = 0.05
+	cavalry_weight = 0.1
+	artillery_weight = 0.3
+	cavalry_cap = 2
+	cost_modifier = 1.5
+    home_province = 1762
+	sprites = { dlc028_hes_sprite_pack westerngfx_sprite_pack }
+    trigger = {
+		OR = {
+			capital_scope = { 
+				OR = {
+					region = south_german_region
+					region = north_german_region
+				}
+			}
+			has_country_modifier = swedish_mercenary_core
+			has_country_modifier = mercenaries_to_the_standard
+			has_country_modifier = glut_of_mercs
+		}
+		custom_trigger_tooltip = {
+			tooltip = new_mercs_tt
+			has_global_flag = new_european_mercs
+		}
+	}
+	modifier = {
+		fire_damage_received = -0.1
+		shock_damage_received = -0.1
+		discipline = 0.025
+
+	}
+}
+
+# Routiers (Britanny, Renaissance)
+merc_routiers = {
+    regiments_per_development = 0.03
+    home_province = 170
+	sprites = { dlc001_bri_sprite_pack dlc087_bri_sprite_pack westerngfx_sprite_pack }
+    trigger = {
+		capital_scope = {
+			OR = {
+				region = france_region
+				region = british_isles_region
+			}
+		}
+		current_age = age_of_discovery
+	}
+}
+
+# Routiers/Bascoli ( Gascony, Renaissance?)
+merc_bascoli = {
+    regiments_per_development = 0.03
+    home_province = 173
+	sprites = { dlc001_amg_sprite_pack dlc049_FRA_sprite_pack dlc028_fra_sprite_pack dlc054_fra_sprite_pack fra_base_sprite_pack }
+    trigger = {
+		OR = {
+			tag = ENG
+			capital_scope = { 
+				OR = {
+					region = iberia_region
+					region = france_region
+				}
+			}
+		}
+		current_age = age_of_discovery
+	}
+}
+	
+# Levends (Dalmatia)
+merc_levends = {
+    regiments_per_development = 0.025
+	cavalry_weight = 0.1
+	artillery_weight = 0.3
+	cavalry_cap = 2
+    home_province = 4754
+	sprites = { easterngfx_sprite_pack }
+    trigger = {
+		any_owned_province = {
+			region = balkan_region
+		}
+	}
+	modifier = { }
+}
+
+# Stratioti (Durres)
+merc_stratioti = {
+    regiments_per_development = 0.025
+    home_province = 4174
+	sprites = { easterngfx_sprite_pack }
+    trigger = {	
+		religion_group = christian
+		any_owned_province = {
+			region = balkan_region
+		}
+	}
+	modifier = { }
+}
+
+# Morlachs (Lika)
+merc_morlachs = {
+    regiments_per_development = 0.025
+	cavalry_weight = 0.1
+	artillery_weight = 0.3
+	cavalry_cap = 2
+    home_province = 1826
+	sprites = { easterngfx_sprite_pack }
+    trigger = {
+		OR = {
+			any_owned_province = {
+				region = balkan_region
+			}
+			has_country_modifier = mercenaries_to_the_standard
+			has_country_modifier = glut_of_mercs
+		}
+	}
+	modifier = { }
+}
+
+# Guardia Corsa (Cosica)
+merc_guardia_corsa = {
+    regiments_per_development = 0.025
+	cavalry_weight = 0.1
+	artillery_weight = 0.3
+	cavalry_cap = 2
+    home_province = 1247
+	sprites = { sav_base_sprite_pack westerngfx_sprite_pack }
+    trigger = {
+		OR = {
+			capital_scope = { region = italy_region }
+			any_owned_province = { area = corsica_sardinia_area }
+		}
+	}
+	modifier = { }
+}
+
+# Hadjduks (Transylvania)
+merc_hadjuks = {
+    regiments_per_development = 0.05
+	cavalry_weight = 0.1
+	artillery_weight = 0.3
+	cavalry_cap = 2
+    home_province = 4128
+    cost_modifier = 0.75
+	sprites = { easterngfx_sprite_pack }
+    trigger = {
+		religion_group = christian
+		capital_scope = {
+			OR = {
+				region = balkan_region
+				region = carpathia_region
+				region = poland_region
+			}
+		}
+	}
+	modifier = { }
+}
+
+# Gallowglasses (Ireland, Renaissance + Reformation)
+merc_gallowglasses = {
+    regiments_per_development = 0.025
+	cavalry_weight = 0.1
+	artillery_weight = 0.3
+	cavalry_cap = 2
+    home_province = 4380
+	sprites = { dlc087_ire_sprite_pack lei_base_sprite_pack westerngfx_sprite_pack }
+    trigger = {
+		OR = {
+			capital_scope = { region = british_isles_region }
+			any_owned_province = {
+				OR = {
+					area = kingdom_of_the_isles_area
+					area = munster_area
+					area = connacht_area
+					area = leinster_area
+					area = ulster_area
+				}
+			}
+			has_country_modifier = mercenaries_to_the_standard
+			has_country_modifier = glut_of_mercs
+		}
+		custom_trigger_tooltip = {
+			tooltip = no_new_mercs_tt
+			NOT = { has_global_flag = new_european_mercs }
+		}
+	}
+	modifier = {
+        discipline = 0.025
+        shock_damage_received = -0.05
+	}
+}
+
+# Redshanks (Scotland, Renaissance + Reformation)
+merc_redshanks = {
+    regiments_per_development = 0.03
+    home_province = 4364
+	sprites = { dlc087_sco_sprite_pack dlc001_sco_sprite_pack sco_base_sprite_pack westerngfx_sprite_pack }
+    trigger = { 
+		OR = {
+			capital_scope = { region = british_isles_region }
+			has_country_modifier = scottish_mercenaries
+			has_country_modifier = swedish_mercenary_core
+			has_country_modifier = mercenaries_to_the_standard
+			has_country_modifier = glut_of_mercs
+		}
+		custom_trigger_tooltip = {
+			tooltip = no_new_mercs_tt
+			NOT = { has_global_flag = new_european_mercs }
+		}
+	}
+	modifier = {
+		shock_damage = 0.05
+	}
+}
+
+# Scottish Guard (Scotland, Absolutism + Revolution)
+merc_scottish_guard = {
+    regiments_per_development = 0.03
+	cavalry_weight = 0.1
+	artillery_weight = 0.3
+	cavalry_cap = 2
+    home_province = 252
+	sprites = { dlc087_sco_sprite_pack dlc001_sco_sprite_pack sco_base_sprite_pack westerngfx_sprite_pack }
+    trigger = { 
+		OR = {
+			capital_scope = { 
+				OR = {
+					region = british_isles_region
+					region = france_region
+				}
+			}
+			has_country_modifier = scottish_mercenaries
+			has_country_modifier = swedish_mercenary_core
+			has_country_modifier = mercenaries_to_the_standard
+			has_country_modifier = glut_of_mercs
+		}
+		custom_trigger_tooltip = {
+			tooltip = new_mercs_tt
+			has_global_flag = new_european_mercs
+		}
+	}
+	modifier = {
+        fire_damage_received = -0.05
+	}
+}
+
+# Seimeni (Reformation + Absolutism)
+merc_seimeni = {
+    regiments_per_development = 0.03
+    home_province = 157
+	sprites = { easterngfx_sprite_pack }
+    trigger = { 
+		OR = {
+			primary_culture = romanian
+			primary_culture = transylvanian
+		}
+		custom_trigger_tooltip = {
+			tooltip = new_mercs_tt
+			has_global_flag = new_european_mercs
+		}
+	}
+}
+
+# Armatoles
+merc_armatoles = {
+    regiments_per_development = 0.025
+    home_province = 1853
+	sprites = { dlc006_byz_sprite_pack easterngfx_sprite_pack }
+    trigger = { 
+		capital_scope = { 
+			OR = {
+				area = thrace_area
+				area = macedonia_area
+				area = northern_greece_area
+				area = morea_area
+			}
+		}
+		1853 = {
+			owner = {
+				primary_culture = turkish
+			}
+		}
+	}
+}
+
+merc_white_company = {
+    regiments_per_development = 0.03
+    home_province = 236
+	sprites = { dlc049_ENG_sprite_pack dlc042_eng_sprite_pack dlc028_eng_sprite_pack eng_base_sprite_pack }
+    trigger = { 
+		OR = {
+			capital_scope = { region = british_isles_region }
+			any_owned_province = { region = british_isles_region }
+			has_country_modifier = mercenaries_to_the_standard
+			has_country_modifier = glut_of_mercs
+		}
+		current_age = age_of_discovery
+	}
+	modifier = { }
+}
+
+merc_flemish_company = {
+    regiments_per_development = 0.04
+	cavalry_weight = 0.1
+	artillery_weight = 0.3
+	cavalry_cap = 2
+    home_province = 90
+	sprites = { dlc042_ned_sprite_pack dlc028_ned_sprite_pack westerngfx_sprite_pack }
+    trigger = {
+		OR = {
+			capital_scope = { 
+				OR = {
+					region = south_german_region
+					region = north_german_region
+					region = low_countries_region
+					region = british_isles_region
+					region = france_region
+				}
+			}
+			any_owned_province = {
+				region = low_countries_region
+			}
+			has_country_modifier = mercenaries_to_the_standard
+			has_country_modifier = glut_of_mercs
+		}
+	}
+	modifier = {
+        infantry_power = 0.05
+	}
+}
+
+merc_forlorn_hope = {
+    regiments_per_development = 0.025
+    home_province = 237 # Oxford
+	cost_modifier = 1.2
+	sprites = { dlc049_ENG_sprite_pack dlc042_eng_sprite_pack dlc028_eng_sprite_pack eng_base_sprite_pack }
+    trigger = {	
+		capital_scope = { region = british_isles_region }
+	}
+	modifier = {
+		reinforce_speed = -0.25
+		fire_damage_received = -0.1
+		shock_damage_received = -0.1
+		land_morale = 0.1
+	}
+}
+
+merc_buccaneer_battalion = {
+    regiments_per_development = 0.05
+    home_province = 489 # Tortuga
+    cost_modifier = 0.67
+	sprites = { dlc098_nss_sprite_pack westerngfx_sprite_pack }
+    trigger = {
+		is_random_new_world = no
+		OR = {
+			custom_trigger_tooltip = {
+				tooltip = golden_age_of_piracy_merc_tt
+				has_global_flag = golden_age_of_piracy
+			}
+			exists = TOR
+		}
+		489 = {
+			is_city = yes
+		}
+	}
+	modifier = {
+		discipline = -0.025
+		movement_speed = 0.2
+	}
+}
+
+merc_bandeirantes = {
+    regiments_per_development = 0.05
+    home_province = 766 # Sao Vicente
+    cost_modifier = 0.8
+	sprites = { dlc011_por_sprite_pack dlc042_por_sprite_pack westerngfx_sprite_pack }
+    trigger = {
+		is_random_new_world = no
+		766 = {
+			is_city = yes
+			owner = {
+				OR = {
+					is_colonial_nation = yes
+					is_former_colonial_nation = yes
+				}
+			}
+		}
+		OR = {
+			is_colonial_nation = yes
+			is_former_colonial_nation = yes
+			any_subject_country = {
+				is_colonial_nation = yes
+			}
+		}
+	}
+	modifier = {
+		discipline = -0.025
+		land_attrition = -0.25
+	}
+}
+
+# Huai Army (China, Anhui, Huai River)
+merc_huai_army = {
+    regiments_per_development = 0.05
+	cavalry_weight = 0.1
+	artillery_weight = 0.3
+	cavalry_cap = 2
+    home_province = 688
+	sprites = { dlc068_mng_sprite_pack mng_base_sprite_pack }
+    trigger = {
+		OR = {
+			capital_scope = {
+				OR = {
+					superregion = china_superregion 
+					superregion = tartary_superregion
+				}
+			}
+			any_owned_province = {
+				superregion = china_superregion 
+			}
+			has_country_modifier = mercenaries_to_the_standard
+			has_country_modifier = glut_of_mercs
+		}
+	}
+	modifier = { }
+}
+
+# Xiang Army (China, Hunan, Xiang River)
+merc_xiang_army = {
+    regiments_per_development = 0.05
+	cavalry_weight = 0.1
+	artillery_weight = 0.3
+	cavalry_cap = 2
+    home_province = 2174
+	sprites = { dlc068_mng_sprite_pack mng_base_sprite_pack }
+    trigger = {
+		OR = {
+			capital_scope = {
+				OR = {
+					superregion = china_superregion 
+					superregion = tartary_superregion
+				}
+			}
+			any_owned_province = {
+				superregion = china_superregion 
+			}
+			has_country_modifier = mercenaries_to_the_standard
+			has_country_modifier = glut_of_mercs
+		}
+	}
+	modifier = { }
+}
+
+# Lang Bing/Wolf Troops (Guangxi)
+merc_wolf_troops = {
+    regiments_per_development = 0.025
+	cavalry_weight = 0.1
+	artillery_weight = 0.3
+	cavalry_cap = 2
+	cost_modifier = 1.2
+    home_province = 2164
+	sprites = { dlc068_mng_sprite_pack mng_base_sprite_pack }
+    trigger = {
+		any_owned_province = {
+			OR = {
+				superregion = china_superregion
+				region = indo_china_region
+				region = manchuria_region
+				region = korea_region
+			}
+		}
+	}
+	modifier = {
+        shock_damage = 0.1
+	}
+}
+
+# Mercenaries from Shanxi
+merc_shanxi_guard = {
+    regiments_per_development = 0.05
+	cavalry_weight = 0.1
+	artillery_weight = 0.3
+	cavalry_cap = 2
+    home_province = 2177
+	sprites = { dlc068_mng_sprite_pack mng_base_sprite_pack }
+    trigger = { 
+		capital_scope = {
+			OR = {
+				superregion = china_superregion 
+				superregion = tartary_superregion
+				region = korea_region
+			}
+		}
+	}
+	modifier = { }
+}
+
+# Mercenaries from Yongning, where the She-An Rebellion started
+merc_yongning_warriors = {
+    regiments_per_development = 0.05
+	cavalry_weight = 0.1
+	artillery_weight = 0.3
+	cavalry_cap = 2
+    home_province = 4213
+	sprites = { dlc068_mng_sprite_pack mng_base_sprite_pack }
+    trigger = { 
+		capital_scope = {
+			OR = {
+				superregion = china_superregion 
+				superregion = tartary_superregion
+			}
+		}
+	}
+	modifier = { }
+}
+
+# Kanto Ronin
+merc_kanto_ronin = {
+    regiments_per_development = 0.025
+    home_province = 1028
+	sprites = { dlc068_jap_sprite_pack jap_base_sprite_pack }
+    trigger = {
+		capital_scope = { region = japan_region }
+	}
+	modifier = { }
+}
+
+# Kyushu Wokou
+merc_kyushu_wokou = {
+    regiments_per_development = 0.025
+    home_province = 1818
+	sprites = { dlc067_smz_sprite_pack jap_base_sprite_pack }
+    trigger = {
+		any_owned_province = {
+			OR = {
+				region = japan_region
+				region = manchuria_region
+				region = korea_region
+			}
+		}
+	}
+	modifier = { }
+}
+
+# Shikoku Yojimbo
+merc_shikoku_yojimbo = {
+    regiments_per_development = 0.025
+    home_province = 1819
+	sprites = { dlc067_hsk_sprite_pack jap_base_sprite_pack }
+    trigger = {	
+		capital_scope = { region = japan_region }
+	}
+	modifier = { }
+}
+
+merc_purbiyas = {
+    regiments_per_development = 0.04
+	artillery_weight = 0.3
+    home_province = 555
+	sprites = { dlc092_jnp_sprite_pack dlh_base_sprite_pack }
+    trigger = {
+		capital_scope = { superregion = india_superregion }
+	}
+	modifier = { }
+}
+
+# Gurkhas
+merc_gorkhalis = {
+    regiments_per_development = 0.025
+	artillery_weight = 0.1
+    home_province = 4485
+    cost_modifier = 1.5
+	sprites = { dlc091_npl_sprite_pack indiangfx_sprite_pack }
+    trigger = {
+		OR = {
+			any_owned_province = {
+				superregion = india_superregion
+			}
+			has_country_modifier = mercenaries_to_the_standard
+			has_country_modifier = glut_of_mercs
+		}
+	}
+	modifier = {
+        infantry_power = 0.05
+        shock_damage = 0.05
+	}
+}
+
+# Gosains
+merc_gosains = {
+    regiments_per_development = 0.03
+	cavalry_weight = 0.1
+	artillery_weight = 0.3
+	cavalry_cap = 2
+	cost_modifier = 1.2
+    home_province = 523
+	sprites = { dlc092_jnp_sprite_pack indiangfx_sprite_pack }
+    trigger = {
+		religion = hinduism
+		any_owned_province = {
+			superregion = india_superregion
+		}
+	}
+	modifier = {
+        land_morale = 0.05
+	}
+}
+
+# Tamil Company
+merc_tamil_company = {
+    regiments_per_development = 0.05
+	cavalry_weight = 0.1
+	artillery_weight = 0.3
+	cavalry_cap = 2
+    home_province = 2085 # Tiruchirappalli
+	sprites = { dlc024_vij_sprite_pack vij_base_sprite_pack }
+    trigger = {
+		any_owned_province = {
+			OR = {
+				region = deccan_region
+				region = coromandel_region
+			}
+		}
+	}
+	modifier = { }
+}
+
+merc_company_of_the_ganges = {
+    regiments_per_development = 0.03
+    home_province = 4497 # Kannauj
+	sprites = { dlc092_jnp_sprite_pack dlh_base_sprite_pack }
+    trigger = {
+		any_owned_province = {
+			OR = {
+				region = bengal_region
+				region = hindusthan_region
+				region = west_india_region
+			}
+		}
+	}
+	modifier = { }
+}
+
+# Banjaras
+merc_banjara_company = {
+    regiments_per_development = 0.05
+    cavalry_weight = 0.4
+    artillery_weight = 0.2
+	cavalry_cap = 6
+	home_province = 514
+	sprites = { dlc091_mer_sprite_pack indiangfx_sprite_pack }
+    trigger = {
+		capital_scope = { superregion = india_superregion }
+	}
+	modifier = { }
+}
+
+# Bukhara Band
+merc_bukhara_band = {
+    regiments_per_development = 0.05
+	cavalry_weight = 0.4
+    artillery_weight = 0.2
+	cavalry_cap = 6
+	home_province = 442
+	sprites = { dlc048_tim_sprite_pack muslimgfx_sprite_pack }
+    trigger = {
+		any_owned_province = {
+			OR = {
+				region = persia_region
+				region = khorasan_region
+				region = central_asia_region
+				region = caucasia_region
+			}
+		}
+	}
+	modifier = { }
+}
+
+# Mesopotamian Mamluks
+merc_mesopotamian_mamluks = {
+    regiments_per_development = 0.05
+    cavalry_weight = 0.4
+    artillery_weight = 0.2
+	cavalry_cap = 6
+	home_province = 410
+	cost_modifier = 1.1
+	sprites = { dlc080_alh_sprite_pack muslimgfx_sprite_pack }
+	trigger = {
+		OR = {
+			capital_scope = {
+				region = mashriq_region
+			}
+			accepted_culture = al_iraqiya_arabic
+			AND = {
+				religion_group = muslim
+				any_owned_province = {
+					region = mashriq_region
+				}
+			}
+		}
+	}
+    modifier = {
+        cavalry_shock = 1.0
+    }
+}
+
+# Nile Mamluks
+merc_nile_mamluks = {
+    regiments_per_development = 0.05
+    cavalry_weight = 0.4
+    artillery_weight = 0.2
+	cavalry_cap = 6
+    home_province = 361
+	cost_modifier = 1.5
+	sprites = { dlc002_mam_sprite_pack dlc058_mam_sprite_pack muslimgfx_sprite_pack }
+	trigger = {
+		NOT = { tag = MAM }
+		NOT = { was_tag = MAM }
+		capital_scope = {
+			OR = {
+				region = mashriq_region
+				region = arabia_region
+				region = egypt_region
+				region = maghreb_region
+			}
+		}
+	}
+    modifier = {
+        cavalry_power = 0.1
+        discipline = 0.025
+    }
+}
+
+merc_delhi_mamluks = {
+    regiments_per_development = 0.05
+    cavalry_weight = 0.4
+    artillery_weight = 0.2
+	cavalry_cap = 6
+    home_province = 522
+	sprites = { dlh_base_sprite_pack }
+	trigger = { 
+		religion_group = muslim
+		capital_scope = {
+			superregion = india_superregion
+		}
+	}
+    modifier = { }
+}
+
+merc_zeybeks = {
+    regiments_per_development = 0.03
+    home_province = 318
+	sprites = { dlc002_tur_sprite_pack dlc042_tur_sprite_pack tur_base_sprite_pack }
+	trigger = {
+		religion_group = muslim
+		any_owned_province = {
+			OR = {
+				area = aegean_archipelago_area
+				area = hudavendigar_area
+				area = aydin_area
+			}
+		}
+	}
+    modifier = { }
+}
+
+merc_sekban = {
+    regiments_per_development = 0.03
+    home_province = 324
+	sprites = { dlc002_tur_sprite_pack dlc042_tur_sprite_pack tur_base_sprite_pack }
+	trigger = {
+		OR = {
+			tag = TUR
+			capital_scope = { region = anatolia_region }
+		}
+	}
+    modifier = { }
+}
+
+merc_zanj_company = {
+    regiments_per_development = 0.05
+    artillery_weight = 0.2
+    home_province = 1199
+	sprites = { dlc057_zan_sprite_pack africangfx_sprite_pack }
+	trigger = {
+		OR = {
+			any_owned_province = {
+				OR = {
+					region = east_africa_region
+					area = mogadishu_area
+				}
+			}
+			capital_scope = {
+				region = arabia_region
+			}
+			has_country_modifier = mercenaries_to_the_standard
+			has_country_modifier = glut_of_mercs
+		}
+	}
+    modifier = { }
+}
+
+merc_madagascar_company = {
+    regiments_per_development = 0.05
+    artillery_weight = 0.2
+    home_province = 1792
+	sprites = { africangfx_sprite_pack }
+	trigger = {
+		OR = {
+			capital_scope = {
+				OR = {
+					region = east_africa_region
+					region = south_africa_region
+				}
+			}
+			any_owned_province = {
+				OR = {
+					area = madagascar_highlands_area
+					area = betsimasaraka_area
+					area = sakalava_area
+					area = southern_madagascar
+				}
+			}
+		}
+	}
+    modifier = { }
+}
+
+merc_sahel_company = {
+    regiments_per_development = 0.05
+    artillery_weight = 0.2
+    home_province = 1132
+	cost_modifier = 1.1
+	sprites = { dlc062_tmb_sprite_pack africangfx_sprite_pack }
+	trigger = {
+		any_owned_province = {
+			OR = {
+				region = sahel_region
+				region = niger_region
+				region = guinea_region
+			}
+		}
+	}
+    modifier = {
+		movement_speed = 0.1
+		land_attrition = -0.25
+	}
+}
+
+merc_asafo_company = {
+    regiments_per_development = 0.05
+    cavalry_weight = 0
+    artillery_weight = 0.2
+	cavalry_cap = 6
+    home_province = 2255
+	cost_modifier = 1.1
+	sprites = { dlc062_msi_sprite_pack africangfx_sprite_pack }
+	trigger = {
+		any_owned_province = {
+			OR = {
+				region = niger_region
+				region = guinea_region
+			}
+		}
+	}
+    modifier = {
+        land_morale = 0.05
+	}
+}
+
+merc_nubian_company = {
+    regiments_per_development = 0.05
+    artillery_weight = 0.2
+    home_province = 2798
+	sprites = { dlc057_nub_sprite_pack africangfx_sprite_pack }
+	trigger = {
+		OR = {
+			capital_scope = {
+				OR = {
+					superregion = near_east_superregion
+					region = horn_of_africa_region
+					region = sahel_region
+					region = maghreb_region
+					region = egypt_region
+				}
+			}
+			any_owned_province = {
+				region = horn_of_africa_region
+			}
+			has_country_modifier = mercenaries_to_the_standard
+			has_country_modifier = glut_of_mercs
+		}
+	}
+    modifier = { }
+}
+
+merc_tonkinese_army = {
+    regiments_per_development = 0.05
+    artillery_weight = 0.2
+    home_province = 2372
+	sprites = { dlc041_dai_sprite_pack dlc090_south_east_asian_elephant_sprite_pack asiangfx_sprite_pack }
+	cost_modifier = 1.1
+	trigger = {
+		OR = {
+			capital_scope = {
+				OR = {
+					superregion = china_superregion
+					superregion = east_indies_superregion
+				}
+			}
+			any_owned_province = {
+				region = indo_china_region
+			}
+			has_country_modifier = mercenaries_to_the_standard
+			has_country_modifier = glut_of_mercs
+		}
+	}
+    modifier = {
+		land_attrition = -0.2
+		reinforce_speed = 0.2
+	}
+}
+
+merc_mongol_mercenaries = {
+    regiments_per_development = 0.05
+    cavalry_weight = 0.4
+    artillery_weight = 0.1
+	cavalry_cap = 6
+	home_province = 2190
+	cost_modifier = 1.5
+	sprites = { dlc069_kha_sprite_pack muslimgfx_sprite_pack }
+	trigger = {
+		OR = {
+			any_neighbor_country = {
+				culture_group = altaic
+			}
+			culture_group = altaic
+			any_owned_province = {
+				OR = {
+					culture_group = altaic
+					region = north_china_region
+					region = mongolia_region
+					region = manchuria_region
+					region = central_asia_region
+				}
+			}
+		}
+	}
+    modifier = {
+        cavalry_power = 0.2
+    }
+}
+
+merc_royal_circassian_guards = {
+    regiments_per_development = 0.025
+	cost_modifier = 1.1
+    home_province = 463 # Circassia proper
+	sprites = { dlc047_cir_sprite_pack easterngfx_sprite_pack }
+	trigger = { 
+		capital_scope = { 
+			OR = {
+				superregion = near_east_superregion 
+				region = crimea_region
+				region = egypt_region
+				region = central_asia_region
+				AND = {
+					region = balkan_region
+					religion_group = muslim
+				}
+			}
+		}
+		government = monarchy
+	}
+    modifier = {
+		prestige_from_land = 0.15
+	}
+}
+
+merc_bedouin_auxiliaries = {
+    regiments_per_development = 0.05
+    cavalry_weight = 0.4
+    artillery_weight = 0.1
+	cavalry_cap = 6
+    home_province = 383 # Tabuk
+	sprites = { dlc080_shm_sprite_pack muslimgfx_sprite_pack }
+	trigger = {
+		OR = {
+			capital_scope = {
+				OR = {
+					superregion = near_east_superregion
+					superregion = persia_superregion
+					region = egypt_region
+					region = maghreb_region
+				}
+			}
+			any_owned_province = {
+				OR = {
+					region = arabia_region
+					region = mashriq_region
+					region = egypt_region
+				}
+			}
+			has_country_modifier = mercenaries_to_the_standard
+			has_country_modifier = glut_of_mercs
+		}
+	}
+    modifier = { }
+}
+
+merc_kurdish_company = {
+    regiments_per_development = 0.02
+    home_province = 4293 # Arbil
+	sprites = { dlc079_hsn_sprite_pack muslimgfx_sprite_pack }
+	trigger = {
+		OR = {
+			capital_scope = {
+				OR = {
+					region = persia_region
+					region = mashriq_region
+					region = anatolia_region
+				}
+			}
+			any_owned_province = {
+				OR = {
+					area = al_jazira_area
+					area = north_kurdistan_area
+				}
+			}
+		}
+	}
+    modifier = { }
+}
+
+merc_laz_auxiliaries = {
+    regiments_per_development = 0.03
+    home_province = 2196 # Guria
+	sprites = { easterngfx_sprite_pack }
+	trigger = {
+		OR = {
+			capital_scope = { region = caucasia_region }
+			tag = BYZ
+		}
+	}
+    modifier = { }
+}
+
+merc_tabarestan_company = {
+    regiments_per_development = 0.03
+    home_province = 417 # Lahijan
+	sprites = { dlc079_tab_sprite_pack muslimgfx_sprite_pack }
+	trigger = {
+		capital_scope = { superregion = persia_superregion }
+	}
+    modifier = { }
+}
+
+merc_novgorod_company = {
+    regiments_per_development = 0.02
+    home_province = 310 # Novogorod
+	sprites = { dlc020_nov_sprite_pack rus_base_sprite_pack easterngfx_sprite_pack }
+	trigger = {
+		capital_scope = { superregion = eastern_europe_superregion }
+	}
+    modifier = { }
+}
+
+merc_crimean_company = {
+    regiments_per_development = 0.03
+    home_province = 284 # Crimea
+	sprites = { dlc047_cri_sprite_pack muslimgfx_sprite_pack }
+	trigger = {
+		OR = {
+			religion_group = muslim
+			religion = tengri_pagan_reformed
+		}
+	}
+    modifier = { }
+}
+
+merc_buryat_band = {
+    regiments_per_development = 0.02
+    artillery_weight = 0 # No artillery
+	cost_modifier = 1.1
+    home_province = 1058 # Onan Gol
+	sprites = { asiangfx_sprite_pack }
+	trigger = {
+		any_owned_province = {
+			OR = {
+				region = east_siberia_region
+				region = mongolia_region
+				region = north_china_region
+				region = manchuria_region
+				region = korea_region
+			}
+		}
+	}
+    modifier = {
+        movement_speed = 0.1
+		raze_power_gain = 0.1
+	}
+}
+
+merc_lithuanian_company = {
+    regiments_per_development = 0.03
+    home_province = 272 # Vilnius
+	sprites = { dlc003_lit_sprite_pack dlc074_lit_sprite_pack easterngfx_sprite_pack }
+	trigger = {
+		any_owned_province = {
+			OR = {
+				region = poland_region
+				region = baltic_region
+				region = ruthenia_region
+			}
+		}
+	}
+    modifier = { }
+}
+
+merc_frisian_free_company = {
+    regiments_per_development = 0.02
+    home_province = 4382 # Groningen
+    cost_modifier = 1.2
+	sprites = { dlc028_ned_sprite_pack dlc042_ned_sprite_pack westerngfx_sprite_pack }
+	trigger = {
+		OR = {
+			capital_scope = { 
+				OR = {
+					region = north_german_region 
+					region = low_countries_region
+				}
+			}
+			any_owned_province = {
+				OR = {
+					area = frisia_area
+					area = weser_area
+				}
+			}
+			has_country_modifier = swedish_mercenary_core
+			has_country_modifier = mercenaries_to_the_standard
+			has_country_modifier = glut_of_mercs
+		}
+	}
+    modifier = {
+        reserves_organisation = 0.05
+		land_morale = 0.05
+	}
+}
+
+merc_finnish_company = {
+    regiments_per_development = 0.04
+    artillery_weight = 0.1
+    home_province = 28 # Nyland
+	sprites = { swe_base_sprite_pack westerngfx_sprite_pack }
+	trigger = {
+		OR = {
+			capital_scope = { region = scandinavia_region }
+			any_owned_province = { area = finland_area }
+			has_country_modifier = mercenaries_to_the_standard
+			has_country_modifier = glut_of_mercs
+		}
+	}
+    modifier = { }
+}
+
+merc_almogavars = {
+    regiments_per_development = 0.02
+    artillery_weight = 0 # No artillery
+    home_province = 1750 # Alicante
+    cost_modifier = 1.1
+	sprites = { dlc020_ara_sprite_pack dlc029_spa_sprite_pack dlc049_SPA_sprite_pack dlc053_spa_sprite_pack westerngfx_sprite_pack }
+	trigger = {
+		culture_group = iberian
+		current_age = age_of_discovery
+	}
+    modifier = {
+        movement_speed = 0.15
+	}
+}
+
+merc_moorish_battalion = {
+    regiments_per_development = 0.03
+    home_province = 343 # Fez
+	sprites = { dlc058_mor_sprite_pack muslimgfx_sprite_pack }
+	trigger = { 
+		OR = {
+			capital_scope = { region = maghreb_region }
+			has_country_modifier = mercenaries_to_the_standard
+			has_country_modifier = glut_of_mercs
+		}
+	}
+    modifier = { }
+}
+
+merc_kutai_company = {
+    regiments_per_development = 0.03
+	home_province = 638 # Kutai
+	sprites = { asiangfx_sprite_pack }
+	trigger = {
+		OR = {
+			capital_scope = {
+				superregion = east_indies_superregion
+			}
+			any_owned_province = {
+				region = indonesia_region
+			}
+			has_country_modifier = mercenaries_to_the_standard
+			has_country_modifier = glut_of_mercs
+		}
+	}
+    modifier = { }
+}
+
+merc_miquelet_company = {
+    regiments_per_development = 0.02
+    home_province = 2987 # Urgell
+	cost_modifier = 1.1
+	sprites = { dlc098_nav_sprite_pack dlc020_ara_sprite_pack dlc029_spa_sprite_pack dlc049_SPA_sprite_pack dlc053_spa_sprite_pack westerngfx_sprite_pack }
+	trigger = {
+		capital_scope = { 
+			OR = {
+				region = iberia_region
+				region = france_region
+			}
+		}
+	}
+    modifier = {
+		movement_speed = 0.1
+		land_attrition = -0.15
+	}
+}
+
+merc_free_company_of_volunteers = {
+    regiments_per_development = 0.03
+    home_province = 4579 # Sayula
+	sprites = { dlc011_spa_sprite_pack westerngfx_sprite_pack }
+	trigger = { 
+		is_random_new_world = no
+		4579 = {
+			is_city = yes
+			owner = {
+				OR = {
+					is_colonial_nation = yes
+					is_former_colonial_nation = yes
+				}
+			}
+		}
+		OR = {
+			is_colonial_nation = yes
+			is_former_colonial_nation = yes
+			any_subject_country = {
+				is_colonial_nation = yes
+			}
+		}
+	}
+    modifier = { }
+}
+
+merc_crabats = {
+    regiments_per_development = 0.025
+    home_province = 131 # Zagreb
+    cavalry_weight = 0.4
+    artillery_weight = 0.1
+	cavalry_cap = 6
+	sprites = { easterngfx_sprite_pack }
+    trigger = {
+		religion_group = christian
+		OR = {
+			capital_scope = { 
+				OR = {
+					region = balkan_region
+					region = south_german_region
+					region = carpathia_region
+				}
+			}
+			any_owned_province = {
+				area = croatia_area
+			}
+		}
+	}
+	modifier = { }
+}
+
+merc_free_swiss_guard = {
+    regiments_per_development = 0.025
+    home_province = 165 # Bern
+	cost_modifier = 1.5
+	sprites = { westerngfx_sprite_pack }
+    trigger = { 
+		OR = {
+			capital_scope = { superregion = europe_superregion }
+			any_owned_province = {
+				OR = {
+					area = switzerland_area
+					area = romandie_area
+				}
+			}
+			has_country_modifier = mercenaries_to_the_standard
+			has_country_modifier = glut_of_mercs
+		}
+		NOT = { tag = PAP }
+	}
+	modifier = {
+        discipline = 0.05
+	}
+}
+
+merc_colonial_rangers = {
+    regiments_per_development = 0.025
+    home_province = 2569 # Eskikewakik, eventually Halifax, Nova Scotia
+    cost_modifier = 1.25
+	artillery_weight = 0.1
+	sprites = { dlc016_eng_sprite_pack westerngfx_sprite_pack }
+	trigger = { 
+		is_random_new_world = no
+		2569 = {
+			is_city = yes
+			owner = {
+				OR = {
+					is_colonial_nation = yes
+					is_former_colonial_nation = yes
+				}
+			}
+		}
+		OR = {
+			is_colonial_nation = yes
+			is_former_colonial_nation = yes
+			any_subject_country = {
+				is_colonial_nation = yes
+			}
+		}
+	}
+    modifier = {
+		movement_speed = 0.1
+        land_morale = 0.1
+	}
+}
+
+merc_independent_cossack_host = {
+    regiments_per_development = 0.05
+    home_province = 283 # Zaporozhia
+	cavalry_weight = 0.4 # lots of cavalry relative to other units
+	artillery_weight = 0 # no artillery
+	cavalry_cap = 6
+	sprites = { dlc047_zaz_sprite_pack easterngfx_sprite_pack }
+	trigger = {
+		OR = {
+			has_estate = estate_cossacks
+			has_reform = cossacks_reform
+			any_neighbor_country = {
+				OR = {
+					has_estate = estate_cossacks
+					has_reform = cossacks_reform
+				}
+			}
+			has_country_modifier = mercenaries_to_the_standard
+			has_country_modifier = glut_of_mercs
+		}
+	}
+    modifier = { }
+}
+
+merc_kazakh_company = {
+    regiments_per_development = 0.05
+    home_province = 478 # Argyn
+	cavalry_weight = 0.4
+	cavalry_cap = 6
+	sprites = { dlc048_shy_sprite_pack muslimgfx_sprite_pack }
+	trigger = {
+		OR = {
+			capital_scope = { region = central_asia_region }
+			has_estate = estate_nomadic_tribes
+			any_neighbor_country = {
+				has_estate = estate_nomadic_tribes
+			}
+			has_country_modifier = mercenaries_to_the_standard
+			has_country_modifier = glut_of_mercs
+		}
+	}
+    modifier = { }
+}
+
+merc_yaka_free_warriors = {
+    regiments_per_development = 0.03
+    home_province = 4085
+	sprites = { africangfx_sprite_pack }
+	trigger = {
+		any_owned_province = {
+			OR = {
+				region = central_africa_region
+				region = kongo_region
+			}
+		}
+	}
+    modifier = { }
+}
+
+merc_great_lakes_free_warriors = {
+    regiments_per_development = 0.03
+    home_province = 4064
+	sprites = { africangfx_sprite_pack }
+	trigger = {
+		OR = {
+			any_owned_province = {
+				region = central_africa_region
+			}
+			has_country_modifier = mercenaries_to_the_standard
+			has_country_modifier = glut_of_mercs
+		}
+	}
+    modifier = { }
+}
+
+merc_thai_company = {
+    regiments_per_development = 0.03
+    home_province = 600
+	sprites = { ayu_base_sprite_pack }
+	trigger = {
+		any_owned_province = {
+			region = indo_china_region
+		}
+	}
+    modifier = { }
+}
+
+merc_yucatan_company = {
+    regiments_per_development = 0.04
+    home_province = 2633 # Ceh Pech
+	sprites = { dlc035_may_sprite_pack southamericagfx_sprite_pack }
+	trigger = {
+		is_random_new_world = no
+		central_america_superregion = {
+			country_or_non_sovereign_subject_holds = root
+		}
+	}
+    modifier = { }
+}
+
+merc_misquito_coast_company = {
+    regiments_per_development = 0.03
+    home_province = 838
+	sprites = { dlc034_tpa_sprite_pack southamericagfx_sprite_pack }
+	trigger = {
+		is_random_new_world = no
+		central_america_superregion = {
+			country_or_non_sovereign_subject_holds = root
+		}
+	}
+    modifier = { }
+}
+
+merc_navajo_raiders = {
+    regiments_per_development = 0.04
+    home_province = 878 # Navajo
+	sprites = { dlc015_nah_sprite_pack northamericagfx_sprite_pack }
+	trigger = {
+		is_random_new_world = no
+		OR = {
+			california_region = {
+				country_or_non_sovereign_subject_holds = root
+			}
+			great_plains_region = {
+				country_or_non_sovereign_subject_holds = root
+			}
+			rio_grande_region = {
+				country_or_non_sovereign_subject_holds = root
+			}
+		}
+	}
+    modifier = { }
+}
+
+merc_chonnonton_warriors = {
+    regiments_per_development = 0.025
+    home_province = 2586
+	sprites = { dlc012_hur_sprite_pack northamericagfx_sprite_pack }
+	trigger = {
+		is_random_new_world = no
+		OR = {
+			northeast_america_region = {
+				country_or_non_sovereign_subject_holds = root
+			}
+			canada_region = {
+				country_or_non_sovereign_subject_holds = root
+			}
+			hudson_bay_region = {
+				country_or_non_sovereign_subject_holds = root
+			}
+			great_lakes_region = {
+				country_or_non_sovereign_subject_holds = root
+			}
+		}
+	}
+    modifier = { }
+}
+
+merc_inuit_warriors = {
+    regiments_per_development = 0.03
+    home_province = 974
+	cost_modifier = 1.1
+	sprites = { inuitgfx_sprite_pack }
+	trigger = {
+		is_random_new_world = no
+		OR = {
+			cascadia_region = {
+				country_or_non_sovereign_subject_holds = root
+			}
+			canada_region = {
+				country_or_non_sovereign_subject_holds = root
+			}
+			hudson_bay_region = {
+				country_or_non_sovereign_subject_holds = root
+			}
+		}
+	}
+    modifier = { shock_damage = 0.1 }
+}
+
+merc_free_mohawks = {
+    regiments_per_development = 0.03
+    home_province = 964
+	cost_modifier = 1.1
+	sprites = { dlc012_iro_sprite_pack northamericagfx_sprite_pack }
+	trigger = {
+		is_random_new_world = no
+		OR = {
+			northeast_america_region = {
+				country_or_non_sovereign_subject_holds = root
+			}
+			canada_region = {
+				country_or_non_sovereign_subject_holds = root
+			}
+		}
+	}
+    modifier = {
+		land_morale = 0.05
+	}
+}
+
+merc_muscogee_mercenaries = {
+    regiments_per_development = 0.04
+    home_province = 925
+	sprites = { dlc012_cre_sprite_pack northamericagfx_sprite_pack }
+	trigger = {
+		is_random_new_world = no
+		OR = {
+			southeast_america_region = {
+				country_or_non_sovereign_subject_holds = root
+			}
+			mississippi_region = {
+				country_or_non_sovereign_subject_holds = root
+			}
+			carribeans_region = {
+				country_or_non_sovereign_subject_holds = root
+			}
+		}
+	}
+    modifier = { }
+}
+
+merc_quito_company = {
+    regiments_per_development = 0.04
+    home_province = 820
+	sprites = { dlc034_inc_sprite_pack southamericagfx_sprite_pack }
+	trigger = {
+		is_random_new_world = no
+		OR = {
+			peru_region = {
+				country_or_non_sovereign_subject_holds = root
+			}
+			colombia_region = {
+				country_or_non_sovereign_subject_holds = root
+			}
+		}
+	}
+    modifier = { }
+}
+
+merc_silver_company = {
+    regiments_per_development = 0.04
+    home_province = 795
+	sprites = { dlc034_inc_sprite_pack southamericagfx_sprite_pack }
+	trigger = {
+		is_random_new_world = no
+		OR = {
+			upper_peru_region = {
+				country_or_non_sovereign_subject_holds = root
+			}
+			la_plata_region = {
+				country_or_non_sovereign_subject_holds = root
+			}
+			brazil_region = {
+				country_or_non_sovereign_subject_holds = root
+			}
+		}
+	}
+    modifier = { }
+}
+
+merc_dahomey_amazons = {
+    regiments_per_development = 0.025
+    cavalry_weight = 0.1
+    artillery_weight = 0.2
+	cavalry_cap = 2
+    home_province = 1140
+	sprites = { dlc062_ben_sprite_pack africangfx_sprite_pack }
+	trigger = {
+		OR = {
+			guinea_region = {
+				country_or_non_sovereign_subject_holds = root
+			}
+			niger_region = {
+				country_or_non_sovereign_subject_holds = root
+			}
+			kongo_region = {
+				country_or_non_sovereign_subject_holds = root
+			}
+			sahel_region = {
+				country_or_non_sovereign_subject_holds = root
+			}
+		}
+	}
+    modifier = {
+        may_recruit_female_generals = yes
+        female_advisor_chance = 1.0
+        shock_damage = 0.05
+        shock_damage_received = -0.05
+    }
+}
+
+merc_gascon_musket_company = {
+    regiments_per_development = 0.025
+    home_province = 175
+    cost_modifier = 1.2
+	sprites = { dlc001_amg_sprite_pack dlc049_FRA_sprite_pack dlc028_fra_sprite_pack dlc054_fra_sprite_pack fra_base_sprite_pack }
+    trigger = {
+		capital_scope = { superregion = europe_superregion }
+		NOT = { current_age = age_of_discovery }
+	}
+	modifier = {
+        infantry_fire = 0.5
+	}
+}
+
+merc_tyrolean_guard = {
+    regiments_per_development = 0.025
+    home_province = 4758
+	sprites = { dlc053_hab_sprite_pack dlc029_hab_sprite_pack hab_base_sprite_pack }
+    trigger = {
+		capital_scope = { region = south_german_region }
+		NOT = { current_age = age_of_discovery }
+	}
+	modifier = { }
+}
+
+merc_mongol_banner = {
+    regiments_per_development = 0.05
+	cavalry_weight = 0.4
+    artillery_weight = 0.2
+	cavalry_cap = 6
+	home_province = 718
+	sprites = { dlc069_kha_sprite_pack muslimgfx_sprite_pack }
+	trigger = {
+		OR = {
+			tag = MJZ
+			tag = MHX
+			tag = MYR
+			tag = MCH
+			tag = QNG
+			tag = EJZ
+		}
+		mission_completed = mch_khan_of_the_mongols
+	}
+	cost_modifier = 1.1
+	modifier = {
+        cavalry_shock =1.0
+	}
+}
+
+merc_swiss_canton_mercenaries = {
+    regiments_per_development = 0.05
+	home_province = 165
+	sprites = { westerngfx_sprite_pack }
+	trigger = {
+		tag = SWI
+		mission_completed = emp_swi_mercenaries
+	}
+	cost_modifier = 0.75
+	modifier = {
+		discipline = 0.05
+	}
+}

--- a/Difficulty and AI changes Full version/common/mercenary_companies/00_mercenaries.txt
+++ b/Difficulty and AI changes Full version/common/mercenary_companies/00_mercenaries.txt
@@ -6,6 +6,12 @@ merc_lombard_free_company = {
 	cavalry_cap = 4
 	sprites = { dlc056_mlo_sprite_pack sav_base_sprite_pack westerngfx_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		custom_trigger_tooltip = {
 			tooltip = italian_wars_flag_tt
 			has_global_flag = italian_wars_global_flag
@@ -46,6 +52,12 @@ merc_tuscan_free_company = {
 	cavalry_cap = 4
 	sprites = { dlc056_lan_sprite_pack sav_base_sprite_pack westerngfx_sprite_pack }
    trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		custom_trigger_tooltip = {
 			tooltip = italian_wars_flag_tt
 			has_global_flag = italian_wars_global_flag
@@ -87,6 +99,12 @@ merc_black_army = {
 	home_province = 153
 	sprites = { easterngfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			has_country_modifier = hun_black_army
 			has_reform = black_army_reform
@@ -107,6 +125,12 @@ merc_black_army_2 = {
 	home_province = 153
 	sprites = { easterngfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		has_reform = black_army_reform
 	}
 	cost_modifier = 0.75
@@ -122,6 +146,12 @@ merc_knights_templar = {
 	cavalry_weight = 0.5
 	sprites = { westerngfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		custom_trigger_tooltip = {
 			tooltip = templars_tt
 			has_country_flag = knights_templar_flag
@@ -140,7 +170,13 @@ merc_swiss_guard = {
     regiments_per_development = 0.005
 	home_province = 166
 	sprites = { dlc029_pap_sprite_pack dlc040_pap_sprite_pack westerngfx_sprite_pack }
-    trigger = { 
+    trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		} 
 		tag = PAP
 		custom_trigger_tooltip = {
 			tooltip = swiss_guard_activated
@@ -160,6 +196,12 @@ merc_bande_nere = {
 	artillery_weight = 0.3
 	sprites = { dlc056_lan_sprite_pack sav_base_sprite_pack westerngfx_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			capital_scope = { 
 				OR = {
@@ -186,6 +228,12 @@ merc_schwarze_garde = {
 	artillery_weight = 0.3
 	sprites = { dlc028_ned_sprite_pack dlc042_ned_sprite_pack westerngfx_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			capital_scope = { 
 				OR = {
@@ -212,6 +260,12 @@ merc_doppelsoeldner = {
     cost_modifier = 1.25
 	sprites = { dlc061_wur_sprite_pack dlc028_wur_sprite_pack westerngfx_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			capital_scope = { 
 				OR = {
@@ -235,6 +289,12 @@ merc_reislaufer = {
 	artillery_weight = 0.3
 	sprites = { westerngfx_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			capital_scope = { 
 				OR = {
@@ -264,6 +324,12 @@ merc_hessian_jaegerkorps = {
     home_province = 1762
 	sprites = { dlc028_hes_sprite_pack westerngfx_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			capital_scope = { 
 				OR = {
@@ -294,6 +360,12 @@ merc_routiers = {
     home_province = 170
 	sprites = { dlc001_bri_sprite_pack dlc087_bri_sprite_pack westerngfx_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		capital_scope = {
 			OR = {
 				region = france_region
@@ -310,6 +382,12 @@ merc_bascoli = {
     home_province = 173
 	sprites = { dlc001_amg_sprite_pack dlc049_FRA_sprite_pack dlc028_fra_sprite_pack dlc054_fra_sprite_pack fra_base_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			tag = ENG
 			capital_scope = { 
@@ -332,6 +410,12 @@ merc_levends = {
     home_province = 4754
 	sprites = { easterngfx_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		any_owned_province = {
 			region = balkan_region
 		}
@@ -344,7 +428,13 @@ merc_stratioti = {
     regiments_per_development = 0.025
     home_province = 4174
 	sprites = { easterngfx_sprite_pack }
-    trigger = {	
+    trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}	
 		religion_group = christian
 		any_owned_province = {
 			region = balkan_region
@@ -362,6 +452,12 @@ merc_morlachs = {
     home_province = 1826
 	sprites = { easterngfx_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			any_owned_province = {
 				region = balkan_region
@@ -382,6 +478,12 @@ merc_guardia_corsa = {
     home_province = 1247
 	sprites = { sav_base_sprite_pack westerngfx_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			capital_scope = { region = italy_region }
 			any_owned_province = { area = corsica_sardinia_area }
@@ -400,6 +502,12 @@ merc_hadjuks = {
     cost_modifier = 0.75
 	sprites = { easterngfx_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		religion_group = christian
 		capital_scope = {
 			OR = {
@@ -421,6 +529,12 @@ merc_gallowglasses = {
     home_province = 4380
 	sprites = { dlc087_ire_sprite_pack lei_base_sprite_pack westerngfx_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			capital_scope = { region = british_isles_region }
 			any_owned_province = {
@@ -451,7 +565,13 @@ merc_redshanks = {
     regiments_per_development = 0.03
     home_province = 4364
 	sprites = { dlc087_sco_sprite_pack dlc001_sco_sprite_pack sco_base_sprite_pack westerngfx_sprite_pack }
-    trigger = { 
+    trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		} 
 		OR = {
 			capital_scope = { region = british_isles_region }
 			has_country_modifier = scottish_mercenaries
@@ -477,7 +597,13 @@ merc_scottish_guard = {
 	cavalry_cap = 2
     home_province = 252
 	sprites = { dlc087_sco_sprite_pack dlc001_sco_sprite_pack sco_base_sprite_pack westerngfx_sprite_pack }
-    trigger = { 
+    trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		} 
 		OR = {
 			capital_scope = { 
 				OR = {
@@ -505,7 +631,13 @@ merc_seimeni = {
     regiments_per_development = 0.03
     home_province = 157
 	sprites = { easterngfx_sprite_pack }
-    trigger = { 
+    trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		} 
 		OR = {
 			primary_culture = romanian
 			primary_culture = transylvanian
@@ -522,7 +654,13 @@ merc_armatoles = {
     regiments_per_development = 0.025
     home_province = 1853
 	sprites = { dlc006_byz_sprite_pack easterngfx_sprite_pack }
-    trigger = { 
+    trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		} 
 		capital_scope = { 
 			OR = {
 				area = thrace_area
@@ -543,7 +681,13 @@ merc_white_company = {
     regiments_per_development = 0.03
     home_province = 236
 	sprites = { dlc049_ENG_sprite_pack dlc042_eng_sprite_pack dlc028_eng_sprite_pack eng_base_sprite_pack }
-    trigger = { 
+    trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		} 
 		OR = {
 			capital_scope = { region = british_isles_region }
 			any_owned_province = { region = british_isles_region }
@@ -563,6 +707,12 @@ merc_flemish_company = {
     home_province = 90
 	sprites = { dlc042_ned_sprite_pack dlc028_ned_sprite_pack westerngfx_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			capital_scope = { 
 				OR = {
@@ -590,7 +740,13 @@ merc_forlorn_hope = {
     home_province = 237 # Oxford
 	cost_modifier = 1.2
 	sprites = { dlc049_ENG_sprite_pack dlc042_eng_sprite_pack dlc028_eng_sprite_pack eng_base_sprite_pack }
-    trigger = {	
+    trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}	
 		capital_scope = { region = british_isles_region }
 	}
 	modifier = {
@@ -607,6 +763,12 @@ merc_buccaneer_battalion = {
     cost_modifier = 0.67
 	sprites = { dlc098_nss_sprite_pack westerngfx_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		is_random_new_world = no
 		OR = {
 			custom_trigger_tooltip = {
@@ -631,6 +793,12 @@ merc_bandeirantes = {
     cost_modifier = 0.8
 	sprites = { dlc011_por_sprite_pack dlc042_por_sprite_pack westerngfx_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		is_random_new_world = no
 		766 = {
 			is_city = yes
@@ -664,6 +832,12 @@ merc_huai_army = {
     home_province = 688
 	sprites = { dlc068_mng_sprite_pack mng_base_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			capital_scope = {
 				OR = {
@@ -690,6 +864,12 @@ merc_xiang_army = {
     home_province = 2174
 	sprites = { dlc068_mng_sprite_pack mng_base_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			capital_scope = {
 				OR = {
@@ -717,6 +897,12 @@ merc_wolf_troops = {
     home_province = 2164
 	sprites = { dlc068_mng_sprite_pack mng_base_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		any_owned_province = {
 			OR = {
 				superregion = china_superregion
@@ -739,7 +925,13 @@ merc_shanxi_guard = {
 	cavalry_cap = 2
     home_province = 2177
 	sprites = { dlc068_mng_sprite_pack mng_base_sprite_pack }
-    trigger = { 
+    trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		} 
 		capital_scope = {
 			OR = {
 				superregion = china_superregion 
@@ -759,7 +951,13 @@ merc_yongning_warriors = {
 	cavalry_cap = 2
     home_province = 4213
 	sprites = { dlc068_mng_sprite_pack mng_base_sprite_pack }
-    trigger = { 
+    trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		} 
 		capital_scope = {
 			OR = {
 				superregion = china_superregion 
@@ -776,6 +974,12 @@ merc_kanto_ronin = {
     home_province = 1028
 	sprites = { dlc068_jap_sprite_pack jap_base_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		capital_scope = { region = japan_region }
 	}
 	modifier = { }
@@ -787,6 +991,12 @@ merc_kyushu_wokou = {
     home_province = 1818
 	sprites = { dlc067_smz_sprite_pack jap_base_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		any_owned_province = {
 			OR = {
 				region = japan_region
@@ -803,7 +1013,13 @@ merc_shikoku_yojimbo = {
     regiments_per_development = 0.025
     home_province = 1819
 	sprites = { dlc067_hsk_sprite_pack jap_base_sprite_pack }
-    trigger = {	
+    trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}	
 		capital_scope = { region = japan_region }
 	}
 	modifier = { }
@@ -815,6 +1031,12 @@ merc_purbiyas = {
     home_province = 555
 	sprites = { dlc092_jnp_sprite_pack dlh_base_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		capital_scope = { superregion = india_superregion }
 	}
 	modifier = { }
@@ -828,6 +1050,12 @@ merc_gorkhalis = {
     cost_modifier = 1.5
 	sprites = { dlc091_npl_sprite_pack indiangfx_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			any_owned_province = {
 				superregion = india_superregion
@@ -852,6 +1080,12 @@ merc_gosains = {
     home_province = 523
 	sprites = { dlc092_jnp_sprite_pack indiangfx_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		religion = hinduism
 		any_owned_province = {
 			superregion = india_superregion
@@ -871,6 +1105,12 @@ merc_tamil_company = {
     home_province = 2085 # Tiruchirappalli
 	sprites = { dlc024_vij_sprite_pack vij_base_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		any_owned_province = {
 			OR = {
 				region = deccan_region
@@ -886,6 +1126,12 @@ merc_company_of_the_ganges = {
     home_province = 4497 # Kannauj
 	sprites = { dlc092_jnp_sprite_pack dlh_base_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		any_owned_province = {
 			OR = {
 				region = bengal_region
@@ -906,6 +1152,12 @@ merc_banjara_company = {
 	home_province = 514
 	sprites = { dlc091_mer_sprite_pack indiangfx_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		capital_scope = { superregion = india_superregion }
 	}
 	modifier = { }
@@ -920,6 +1172,12 @@ merc_bukhara_band = {
 	home_province = 442
 	sprites = { dlc048_tim_sprite_pack muslimgfx_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		any_owned_province = {
 			OR = {
 				region = persia_region
@@ -942,6 +1200,12 @@ merc_mesopotamian_mamluks = {
 	cost_modifier = 1.1
 	sprites = { dlc080_alh_sprite_pack muslimgfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			capital_scope = {
 				region = mashriq_region
@@ -970,6 +1234,12 @@ merc_nile_mamluks = {
 	cost_modifier = 1.5
 	sprites = { dlc002_mam_sprite_pack dlc058_mam_sprite_pack muslimgfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		NOT = { tag = MAM }
 		NOT = { was_tag = MAM }
 		capital_scope = {
@@ -994,7 +1264,13 @@ merc_delhi_mamluks = {
 	cavalry_cap = 6
     home_province = 522
 	sprites = { dlh_base_sprite_pack }
-	trigger = { 
+	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		} 
 		religion_group = muslim
 		capital_scope = {
 			superregion = india_superregion
@@ -1008,6 +1284,12 @@ merc_zeybeks = {
     home_province = 318
 	sprites = { dlc002_tur_sprite_pack dlc042_tur_sprite_pack tur_base_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		religion_group = muslim
 		any_owned_province = {
 			OR = {
@@ -1025,6 +1307,12 @@ merc_sekban = {
     home_province = 324
 	sprites = { dlc002_tur_sprite_pack dlc042_tur_sprite_pack tur_base_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			tag = TUR
 			capital_scope = { region = anatolia_region }
@@ -1039,6 +1327,12 @@ merc_zanj_company = {
     home_province = 1199
 	sprites = { dlc057_zan_sprite_pack africangfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			any_owned_province = {
 				OR = {
@@ -1062,6 +1356,12 @@ merc_madagascar_company = {
     home_province = 1792
 	sprites = { africangfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			capital_scope = {
 				OR = {
@@ -1089,6 +1389,12 @@ merc_sahel_company = {
 	cost_modifier = 1.1
 	sprites = { dlc062_tmb_sprite_pack africangfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		any_owned_province = {
 			OR = {
 				region = sahel_region
@@ -1112,6 +1418,12 @@ merc_asafo_company = {
 	cost_modifier = 1.1
 	sprites = { dlc062_msi_sprite_pack africangfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		any_owned_province = {
 			OR = {
 				region = niger_region
@@ -1130,6 +1442,12 @@ merc_nubian_company = {
     home_province = 2798
 	sprites = { dlc057_nub_sprite_pack africangfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			capital_scope = {
 				OR = {
@@ -1157,6 +1475,12 @@ merc_tonkinese_army = {
 	sprites = { dlc041_dai_sprite_pack dlc090_south_east_asian_elephant_sprite_pack asiangfx_sprite_pack }
 	cost_modifier = 1.1
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			capital_scope = {
 				OR = {
@@ -1186,6 +1510,12 @@ merc_mongol_mercenaries = {
 	cost_modifier = 1.5
 	sprites = { dlc069_kha_sprite_pack muslimgfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			any_neighbor_country = {
 				culture_group = altaic
@@ -1212,7 +1542,13 @@ merc_royal_circassian_guards = {
 	cost_modifier = 1.1
     home_province = 463 # Circassia proper
 	sprites = { dlc047_cir_sprite_pack easterngfx_sprite_pack }
-	trigger = { 
+	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		} 
 		capital_scope = { 
 			OR = {
 				superregion = near_east_superregion 
@@ -1240,6 +1576,12 @@ merc_bedouin_auxiliaries = {
     home_province = 383 # Tabuk
 	sprites = { dlc080_shm_sprite_pack muslimgfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			capital_scope = {
 				OR = {
@@ -1268,6 +1610,12 @@ merc_kurdish_company = {
     home_province = 4293 # Arbil
 	sprites = { dlc079_hsn_sprite_pack muslimgfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			capital_scope = {
 				OR = {
@@ -1292,6 +1640,12 @@ merc_laz_auxiliaries = {
     home_province = 2196 # Guria
 	sprites = { easterngfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			capital_scope = { region = caucasia_region }
 			tag = BYZ
@@ -1305,6 +1659,12 @@ merc_tabarestan_company = {
     home_province = 417 # Lahijan
 	sprites = { dlc079_tab_sprite_pack muslimgfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		capital_scope = { superregion = persia_superregion }
 	}
     modifier = { }
@@ -1315,6 +1675,12 @@ merc_novgorod_company = {
     home_province = 310 # Novogorod
 	sprites = { dlc020_nov_sprite_pack rus_base_sprite_pack easterngfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		capital_scope = { superregion = eastern_europe_superregion }
 	}
     modifier = { }
@@ -1325,6 +1691,12 @@ merc_crimean_company = {
     home_province = 284 # Crimea
 	sprites = { dlc047_cri_sprite_pack muslimgfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			religion_group = muslim
 			religion = tengri_pagan_reformed
@@ -1340,6 +1712,12 @@ merc_buryat_band = {
     home_province = 1058 # Onan Gol
 	sprites = { asiangfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		any_owned_province = {
 			OR = {
 				region = east_siberia_region
@@ -1361,6 +1739,12 @@ merc_lithuanian_company = {
     home_province = 272 # Vilnius
 	sprites = { dlc003_lit_sprite_pack dlc074_lit_sprite_pack easterngfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		any_owned_province = {
 			OR = {
 				region = poland_region
@@ -1378,6 +1762,12 @@ merc_frisian_free_company = {
     cost_modifier = 1.2
 	sprites = { dlc028_ned_sprite_pack dlc042_ned_sprite_pack westerngfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			capital_scope = { 
 				OR = {
@@ -1408,6 +1798,12 @@ merc_finnish_company = {
     home_province = 28 # Nyland
 	sprites = { swe_base_sprite_pack westerngfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			capital_scope = { region = scandinavia_region }
 			any_owned_province = { area = finland_area }
@@ -1425,6 +1821,12 @@ merc_almogavars = {
     cost_modifier = 1.1
 	sprites = { dlc020_ara_sprite_pack dlc029_spa_sprite_pack dlc049_SPA_sprite_pack dlc053_spa_sprite_pack westerngfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		culture_group = iberian
 		current_age = age_of_discovery
 	}
@@ -1437,7 +1839,13 @@ merc_moorish_battalion = {
     regiments_per_development = 0.03
     home_province = 343 # Fez
 	sprites = { dlc058_mor_sprite_pack muslimgfx_sprite_pack }
-	trigger = { 
+	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		} 
 		OR = {
 			capital_scope = { region = maghreb_region }
 			has_country_modifier = mercenaries_to_the_standard
@@ -1452,6 +1860,12 @@ merc_kutai_company = {
 	home_province = 638 # Kutai
 	sprites = { asiangfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			capital_scope = {
 				superregion = east_indies_superregion
@@ -1472,6 +1886,12 @@ merc_miquelet_company = {
 	cost_modifier = 1.1
 	sprites = { dlc098_nav_sprite_pack dlc020_ara_sprite_pack dlc029_spa_sprite_pack dlc049_SPA_sprite_pack dlc053_spa_sprite_pack westerngfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		capital_scope = { 
 			OR = {
 				region = iberia_region
@@ -1489,7 +1909,13 @@ merc_free_company_of_volunteers = {
     regiments_per_development = 0.03
     home_province = 4579 # Sayula
 	sprites = { dlc011_spa_sprite_pack westerngfx_sprite_pack }
-	trigger = { 
+	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		} 
 		is_random_new_world = no
 		4579 = {
 			is_city = yes
@@ -1519,6 +1945,12 @@ merc_crabats = {
 	cavalry_cap = 6
 	sprites = { easterngfx_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		religion_group = christian
 		OR = {
 			capital_scope = { 
@@ -1541,7 +1973,13 @@ merc_free_swiss_guard = {
     home_province = 165 # Bern
 	cost_modifier = 1.5
 	sprites = { westerngfx_sprite_pack }
-    trigger = { 
+    trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		} 
 		OR = {
 			capital_scope = { superregion = europe_superregion }
 			any_owned_province = {
@@ -1566,7 +2004,13 @@ merc_colonial_rangers = {
     cost_modifier = 1.25
 	artillery_weight = 0.1
 	sprites = { dlc016_eng_sprite_pack westerngfx_sprite_pack }
-	trigger = { 
+	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		} 
 		is_random_new_world = no
 		2569 = {
 			is_city = yes
@@ -1599,6 +2043,12 @@ merc_independent_cossack_host = {
 	cavalry_cap = 6
 	sprites = { dlc047_zaz_sprite_pack easterngfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			has_estate = estate_cossacks
 			has_reform = cossacks_reform
@@ -1622,6 +2072,12 @@ merc_kazakh_company = {
 	cavalry_cap = 6
 	sprites = { dlc048_shy_sprite_pack muslimgfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			capital_scope = { region = central_asia_region }
 			has_estate = estate_nomadic_tribes
@@ -1640,6 +2096,12 @@ merc_yaka_free_warriors = {
     home_province = 4085
 	sprites = { africangfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		any_owned_province = {
 			OR = {
 				region = central_africa_region
@@ -1655,6 +2117,12 @@ merc_great_lakes_free_warriors = {
     home_province = 4064
 	sprites = { africangfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			any_owned_province = {
 				region = central_africa_region
@@ -1671,6 +2139,12 @@ merc_thai_company = {
     home_province = 600
 	sprites = { ayu_base_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		any_owned_province = {
 			region = indo_china_region
 		}
@@ -1683,6 +2157,12 @@ merc_yucatan_company = {
     home_province = 2633 # Ceh Pech
 	sprites = { dlc035_may_sprite_pack southamericagfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		is_random_new_world = no
 		central_america_superregion = {
 			country_or_non_sovereign_subject_holds = root
@@ -1696,6 +2176,12 @@ merc_misquito_coast_company = {
     home_province = 838
 	sprites = { dlc034_tpa_sprite_pack southamericagfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		is_random_new_world = no
 		central_america_superregion = {
 			country_or_non_sovereign_subject_holds = root
@@ -1709,6 +2195,12 @@ merc_navajo_raiders = {
     home_province = 878 # Navajo
 	sprites = { dlc015_nah_sprite_pack northamericagfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		is_random_new_world = no
 		OR = {
 			california_region = {
@@ -1730,6 +2222,12 @@ merc_chonnonton_warriors = {
     home_province = 2586
 	sprites = { dlc012_hur_sprite_pack northamericagfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		is_random_new_world = no
 		OR = {
 			northeast_america_region = {
@@ -1755,6 +2253,12 @@ merc_inuit_warriors = {
 	cost_modifier = 1.1
 	sprites = { inuitgfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		is_random_new_world = no
 		OR = {
 			cascadia_region = {
@@ -1777,6 +2281,12 @@ merc_free_mohawks = {
 	cost_modifier = 1.1
 	sprites = { dlc012_iro_sprite_pack northamericagfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		is_random_new_world = no
 		OR = {
 			northeast_america_region = {
@@ -1797,6 +2307,12 @@ merc_muscogee_mercenaries = {
     home_province = 925
 	sprites = { dlc012_cre_sprite_pack northamericagfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		is_random_new_world = no
 		OR = {
 			southeast_america_region = {
@@ -1818,6 +2334,12 @@ merc_quito_company = {
     home_province = 820
 	sprites = { dlc034_inc_sprite_pack southamericagfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		is_random_new_world = no
 		OR = {
 			peru_region = {
@@ -1836,6 +2358,12 @@ merc_silver_company = {
     home_province = 795
 	sprites = { dlc034_inc_sprite_pack southamericagfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		is_random_new_world = no
 		OR = {
 			upper_peru_region = {
@@ -1860,6 +2388,12 @@ merc_dahomey_amazons = {
     home_province = 1140
 	sprites = { dlc062_ben_sprite_pack africangfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			guinea_region = {
 				country_or_non_sovereign_subject_holds = root
@@ -1889,6 +2423,12 @@ merc_gascon_musket_company = {
     cost_modifier = 1.2
 	sprites = { dlc001_amg_sprite_pack dlc049_FRA_sprite_pack dlc028_fra_sprite_pack dlc054_fra_sprite_pack fra_base_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		capital_scope = { superregion = europe_superregion }
 		NOT = { current_age = age_of_discovery }
 	}
@@ -1902,6 +2442,12 @@ merc_tyrolean_guard = {
     home_province = 4758
 	sprites = { dlc053_hab_sprite_pack dlc029_hab_sprite_pack hab_base_sprite_pack }
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		capital_scope = { region = south_german_region }
 		NOT = { current_age = age_of_discovery }
 	}
@@ -1916,6 +2462,12 @@ merc_mongol_banner = {
 	home_province = 718
 	sprites = { dlc069_kha_sprite_pack muslimgfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		OR = {
 			tag = MJZ
 			tag = MHX
@@ -1937,6 +2489,12 @@ merc_swiss_canton_mercenaries = {
 	home_province = 165
 	sprites = { westerngfx_sprite_pack }
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		tag = SWI
 		mission_completed = emp_swi_mercenaries
 	}

--- a/Difficulty and AI changes Full version/common/mercenary_companies/example.txt
+++ b/Difficulty and AI changes Full version/common/mercenary_companies/example.txt
@@ -1,0 +1,102 @@
+#
+# Example mercenary companies
+#
+
+merc__local_free_company = {
+    regiments_per_development = 0.025
+    cavalry_weight = 0.1
+    artillery_weight = 0.1
+    cavalry_cap = 2
+    cost_modifier = 0.75
+    trigger = {
+        total_development = 150
+    }
+    # No home province means local mercenary company
+}
+
+merc__local_small_company = {
+    regiments_per_development = 0.07
+    cavalry_weight = 0.1
+    artillery_weight = 0.1
+    cavalry_cap = 2
+    trigger = {
+        NOT = { total_development = 150 }
+    }
+    cost_modifier = 0.3
+    modifier = {
+        reinforce_speed = -0.25
+        recover_army_morale_speed = -0.1
+    }
+    # No home province means local mercenary company
+}
+
+merc__local_free_city_company = {
+    regiments_per_development = 0.1
+    cavalry_weight = 0.1
+    artillery_weight = 0.1
+    cavalry_cap = 2
+    trigger = {
+        has_reform = free_city
+    }
+    cost_modifier = 0.3
+    modifier = {
+        reinforce_speed = -0.25
+        recover_army_morale_speed = -0.1
+    }
+    # No home province means local mercenary company
+}
+
+merc__local_grand_company = {
+    regiments_per_development = 0.05
+    cavalry_weight = 0.1
+    artillery_weight = 0.1
+    cavalry_cap = 2
+    cost_modifier = 0.75
+    trigger = {
+        total_development = 150
+    }
+    # No home province means local mercenary company
+}
+
+merc__local_independent_army = {
+    regiments_per_development = 0.075
+    cavalry_weight = 0.1
+    artillery_weight = 0.1
+    cavalry_cap = 2
+    cost_modifier = 0.75
+    trigger = {
+        total_development = 150
+    }
+    # No home province means local mercenary company
+}
+
+merc_local_all_female_company = {
+	regiments_per_development = 0.025
+	cavalry_weight = 0.1
+    artillery_weight = 0.1
+    cavalry_cap = 2
+	trigger = {
+		has_country_flag = female_mercs
+	}
+	modifier = {
+		shock_damage_received = 0.05
+		land_morale = 0.05
+    }
+}
+
+twenty_good_men = {
+    regiments_per_development = 0.01
+    cavalry_weight = 0.2
+	artillery_weight = 0.1
+    cavalry_cap = 4
+	cost_modifier = 1.5
+    home_province = 4365
+	trigger = {
+		capital_scope = {
+			province_id = 4365
+		}
+	}
+	modifier = {
+		land_morale = 0.15
+	}
+}

--- a/Difficulty and AI changes Full version/common/mercenary_companies/example.txt
+++ b/Difficulty and AI changes Full version/common/mercenary_companies/example.txt
@@ -9,6 +9,12 @@ merc__local_free_company = {
     cavalry_cap = 2
     cost_modifier = 0.75
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
         total_development = 150
     }
     # No home province means local mercenary company
@@ -20,6 +26,12 @@ merc__local_small_company = {
     artillery_weight = 0.1
     cavalry_cap = 2
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
         NOT = { total_development = 150 }
     }
     cost_modifier = 0.3
@@ -36,6 +48,12 @@ merc__local_free_city_company = {
     artillery_weight = 0.1
     cavalry_cap = 2
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
         has_reform = free_city
     }
     cost_modifier = 0.3
@@ -53,6 +71,12 @@ merc__local_grand_company = {
     cavalry_cap = 2
     cost_modifier = 0.75
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
         total_development = 150
     }
     # No home province means local mercenary company
@@ -65,6 +89,12 @@ merc__local_independent_army = {
     cavalry_cap = 2
     cost_modifier = 0.75
     trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
         total_development = 150
     }
     # No home province means local mercenary company
@@ -76,6 +106,12 @@ merc_local_all_female_company = {
     artillery_weight = 0.1
     cavalry_cap = 2
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		has_country_flag = female_mercs
 	}
 	modifier = {
@@ -92,6 +128,12 @@ twenty_good_men = {
 	cost_modifier = 1.5
     home_province = 4365
 	trigger = {
+		hidden_trigger = {
+			OR = {
+				ai = no
+				NOT = { army_size_percentage = 1 }
+			}
+		}
 		capital_scope = {
 			province_id = 4365
 		}

--- a/Difficulty and AI changes Full version/events/disband_mercs_event.txt
+++ b/Difficulty and AI changes Full version/events/disband_mercs_event.txt
@@ -52,9 +52,7 @@ country_event = { # Disbands Merc companies one at time, if AI went over the for
 		ai = yes
 		is_at_war = yes
 		army_size_percentage = 1.25
-		any_hired_mercenary_company = {
-			hired_for_months = 1
-		}
+		num_of_hired_mercenary_companies = 2
 	}
 	
 	immediate = {


### PR DESCRIPTION
Modify the merc company triggers to prevent the AI from purchasing merc companies when they are over the force limit.

Specific conditionals can be adjusted but the goal is to prevent the merc cleanup script 2 from firing repetitively.