### PR TITLE
Manufactory fix

### DIFF
--- a/common/buildings/00_buildings.txt
+++ b/common/buildings/00_buildings.txt
@@ -181,7 +181,7 @@ workshop = {
 			NOT = { num_free_building_slots = 2 }
 			#NOT = { trade_goods = gold }
 			NOT = {
-				has_building = manufactory
+				has_manufactory_trigger = yes
 			}
 		}
 	}
@@ -2493,7 +2493,7 @@ counting_house = {
 			#NOT = { trade_goods = gold }
 			NOT = { has_building = workshop }
 			NOT = {
-				has_building = manufactory
+				has_manufactory_trigger = yes
 			}
 		}
 	}

--- a/common/scripted_triggers/dif_triggers.txt
+++ b/common/scripted_triggers/dif_triggers.txt
@@ -17,7 +17,7 @@ any_state_edict = {
 building_slot_for_manufactory_trigger = {
 	NOT = { num_free_building_slots = 2 }
 	NOT = { trade_goods = gold }
-	NOT = { has_building = manufactory }
+	NOT = { has_manufactory_trigger = yes }
 }
 
 not_core_or_claim = {


### PR DESCRIPTION
`has_building = manufactory` generates errors in the log, because "manufactory" is not recognized as a building.

Here I changed such triggers to use the scripted trigger `has_manufactory_trigger`, which achieves the intended effect without errors.