### PR TITLE
Adjust Tripitaka so it does not develop institutions like Colonization

### DIFF
--- a/common/event_modifiers/tripitaka_nerf.txt
+++ b/common/event_modifiers/tripitaka_nerf.txt
@@ -1,0 +1,6 @@
+tripitaka_koreana = {
+	harmonization_speed = 0.1
+	yearly_karma_decay = 0.01
+	monthly_splendor = 1
+	church_loyalty_modifier = 0.1 #changed from institution_growth = 3 #so that it will not just develop institutions like Colonization on its own
+}


### PR DESCRIPTION
Added a decent church estate loyalty bonus to the Tripitaka Koreana modifier, replacing its ability to develop, on its own, institutions like Colonization inside a supposedly inwards-focused Hermit Kingdom.