### PR TITLE
Estate privilege ai revocation bugfix

### DIFF
--- a/common/estate_privileges/0002_rajput_privileges.txt
+++ b/common/estate_privileges/0002_rajput_privileges.txt
@@ -185,10 +185,21 @@ estate_rajput_land_rights = {
 		}
 		modifier = {
 			factor = 0.25
-			NOT = { has_estate_privilege = estate_brahmins_brahmin_governance }
+			NOT = { has_estate_privilege = estate_rajput_military }
 			num_of_estate_privileges = {
-				estate = estate_brahmins
-				value = 5
+				estate = estate_rajput
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_rajput
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_rajput
+			    loyalty = 50
 			}
 		}
 	}
@@ -220,10 +231,21 @@ estate_rajput_rajput_regiments = {
 		factor = 10
 		modifier = {
 			factor = 0.25
-			NOT = { has_estate_privilege = estate_brahmins_brahmin_governance }
+			NOT = { has_estate_privilege = estate_rajput_military }
 			num_of_estate_privileges = {
-				estate = estate_brahmins
-				value = 5
+				estate = estate_rajput
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_rajput
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_rajput
+			    loyalty = 50
 			}
 		}
 	}
@@ -321,7 +343,18 @@ estate_rajput_advisor = {
 			NOT = { has_estate_privilege = estate_rajput_military }
 			num_of_estate_privileges = {
 				estate = estate_rajput
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_rajput
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_rajput
+			    loyalty = 50
 			}
 		}
 	}
@@ -348,7 +381,18 @@ estate_rajput_loyalty_privilege = {
 			NOT = { has_estate_privilege = estate_rajput_military }
 			num_of_estate_privileges = {
 				estate = estate_rajput
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_rajput
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_rajput
+			    loyalty = 50
 			}
 		}
 	}
@@ -386,7 +430,18 @@ estate_rajput_officer_corp = {
 			NOT = { has_estate_privilege = estate_rajput_military }
 			num_of_estate_privileges = {
 				estate = estate_rajput
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_rajput
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_rajput
+			    loyalty = 50
 			}
 		}
 	}
@@ -462,7 +517,18 @@ estate_rajput_look_up_purbias = {
 			NOT = { has_estate_privilege = estate_rajput_military }
 			num_of_estate_privileges = {
 				estate = estate_rajput
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_rajput
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_rajput
+			    loyalty = 50
 			}
 		}
 	}
@@ -964,10 +1030,21 @@ estate_rajput_subject_rights = {
 		}
 		modifier = {
 			factor = 0.25
-			NOT = { has_estate_privilege = estate_brahmins_brahmin_governance }
+			NOT = { has_estate_privilege = estate_rajput_military }
 			num_of_estate_privileges = {
-				estate = estate_brahmins
-				value = 5
+				estate = estate_rajput
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_rajput
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_rajput
+			    loyalty = 50
 			}
 		}
 	}
@@ -1013,10 +1090,21 @@ estate_rajput_better_integration = {
 		factor = 10
 		modifier = {
 			factor = 0.25
-			NOT = { has_estate_privilege = estate_brahmins_brahmin_governance }
+			NOT = { has_estate_privilege = estate_rajput_military }
 			num_of_estate_privileges = {
-				estate = estate_brahmins
-				value = 5
+				estate = estate_rajput
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_rajput
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_rajput
+			    loyalty = 50
 			}
 		}
 	}

--- a/common/estate_privileges/001_brahmin_privileges.txt
+++ b/common/estate_privileges/001_brahmin_privileges.txt
@@ -188,7 +188,18 @@ estate_brahmins_land_rights = {
 			NOT = { has_estate_privilege = estate_brahmins_brahmin_governance }
 			num_of_estate_privileges = {
 				estate = estate_brahmins
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_brahmins
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_brahmins
+			    loyalty = 50
 			}
 		}
 	}
@@ -298,7 +309,18 @@ estate_brahmins_legitimacy_to_rule = {
 			NOT = { has_estate_privilege = estate_brahmins_brahmin_governance }
 			num_of_estate_privileges = {
 				estate = estate_brahmins
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_brahmins
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_brahmins
+			    loyalty = 50
 			}
 		}
 	}
@@ -334,7 +356,18 @@ estate_brahmins_brahmin_leadership = {
 			NOT = { has_estate_privilege = estate_brahmins_brahmin_governance }
 			num_of_estate_privileges = {
 				estate = estate_brahmins
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_brahmins
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_brahmins
+			    loyalty = 50
 			}
 		}
 	}
@@ -396,7 +429,18 @@ estate_brahmins_loyalty_privilege = {
 			NOT = { has_estate_privilege = estate_brahmins_brahmin_governance }
 			num_of_estate_privileges = {
 				estate = estate_brahmins
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_brahmins
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_brahmins
+			    loyalty = 50
 			}
 		}
 	}
@@ -1126,7 +1170,18 @@ estate_brahmins_one_faith_one_culture = {
 			NOT = { has_estate_privilege = estate_brahmins_brahmin_governance }
 			num_of_estate_privileges = {
 				estate = estate_brahmins
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_brahmins
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_brahmins
+			    loyalty = 50
 			}
 		}
 	}
@@ -1328,7 +1383,18 @@ estate_brahmins_clerical_education = {
 			NOT = { has_estate_privilege = estate_brahmins_brahmin_governance }
 			num_of_estate_privileges = {
 				estate = estate_brahmins
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_brahmins
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_brahmins
+			    loyalty = 50
 			}
 		}
 	}
@@ -1397,7 +1463,18 @@ estate_brahmins_institutionalized_brahimns = {
 			NOT = { has_estate_privilege = estate_brahmins_brahmin_governance }
 			num_of_estate_privileges = {
 				estate = estate_brahmins
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_brahmins
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_brahmins
+			    loyalty = 50
 			}
 		}
 	}
@@ -1470,7 +1547,18 @@ estate_brahmins_donation_right = {
 			NOT = { has_estate_privilege = estate_brahmins_brahmin_governance }
 			num_of_estate_privileges = {
 				estate = estate_brahmins
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_brahmins
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_brahmins
+			    loyalty = 50
 			}
 		}
 	}

--- a/common/estate_privileges/002_maratha_privileges.txt
+++ b/common/estate_privileges/002_maratha_privileges.txt
@@ -188,7 +188,18 @@ estate_maratha_land_rights = {
 			NOT = { has_estate_privilege = estate_maratha_military }
 			num_of_estate_privileges = {
 				estate = estate_maratha
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_maratha
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_maratha
+			    loyalty = 50
 			}
 		}
 	}
@@ -285,7 +296,18 @@ estate_maratha_advisor = {
 			NOT = { has_estate_privilege = estate_maratha_military }
 			num_of_estate_privileges = {
 				estate = estate_maratha
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_maratha
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_maratha
+			    loyalty = 50
 			}
 		}
 	}
@@ -312,7 +334,18 @@ estate_maratha_loyalty_privilege = {
 			NOT = { has_estate_privilege = estate_maratha_military }
 			num_of_estate_privileges = {
 				estate = estate_maratha
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_maratha
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_maratha
+			    loyalty = 50
 			}
 		}
 	}
@@ -434,7 +467,18 @@ estate_maratha_levies = {
 			NOT = { has_estate_privilege = estate_maratha_military }
 			num_of_estate_privileges = {
 				estate = estate_maratha
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_maratha
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_maratha
+			    loyalty = 50
 			}
 		}
 	}
@@ -532,7 +576,18 @@ estate_maratha_special_privilege = {
 			NOT = { has_estate_privilege = estate_maratha_military }
 			num_of_estate_privileges = {
 				estate = estate_maratha
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_maratha
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_maratha
+			    loyalty = 50
 			}
 		}
 	}
@@ -1077,7 +1132,18 @@ estate_maratha_better_integration = {
 			NOT = { has_estate_privilege = estate_maratha_military }
 			num_of_estate_privileges = {
 				estate = estate_maratha
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_maratha
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_maratha
+			    loyalty = 50
 			}
 		}
 	}

--- a/common/estate_privileges/01_church_privileges.txt
+++ b/common/estate_privileges/01_church_privileges.txt
@@ -205,7 +205,18 @@ estate_church_land_rights = {
 			NOT = { has_estate_privilege = estate_church_religious_state }
 			num_of_estate_privileges = {
 				estate = estate_church
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_church
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_church
+			    loyalty = 50
 			}
 		}
 	}
@@ -319,7 +330,18 @@ estate_church_independent_inquisition = {
 			NOT = { has_estate_privilege = estate_church_religious_state }
 			num_of_estate_privileges = {
 				estate = estate_church
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_church
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_church
+			    loyalty = 50
 			}
 		}
 	}
@@ -460,7 +482,18 @@ estate_church_papal_emissary = {
 			NOT = { has_estate_privilege = estate_church_religious_state }
 			num_of_estate_privileges = {
 				estate = estate_church
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_church
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_church
+			    loyalty = 50
 			}
 		}
 	}
@@ -662,7 +695,18 @@ estate_church_clerical_ministers = {
 			NOT = { has_estate_privilege = estate_church_religious_state }
 			num_of_estate_privileges = {
 				estate = estate_church
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_church
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_church
+			    loyalty = 50
 			}
 		}
 	}
@@ -718,7 +762,18 @@ estate_church_freedom_of_interpretation = {
 			NOT = { has_estate_privilege = estate_church_religious_state }
 			num_of_estate_privileges = {
 				estate = estate_church
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_church
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_church
+			    loyalty = 50
 			}
 		}
 	}
@@ -753,7 +808,18 @@ estate_church_clerical_oversight = {
 			NOT = { has_estate_privilege = estate_church_religious_state }
 			num_of_estate_privileges = {
 				estate = estate_church
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_church
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_church
+			    loyalty = 50
 			}
 		}
 	}
@@ -1789,7 +1855,18 @@ estate_church_influence_temples = {
 			NOT = { has_estate_privilege = estate_church_religious_state }
 			num_of_estate_privileges = {
 				estate = estate_church
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_church
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_church
+			    loyalty = 50
 			}
 		}
 	}
@@ -2079,7 +2156,18 @@ estate_church_one_faith_one_culture = {
 			NOT = { has_estate_privilege = estate_church_religious_state }
 			num_of_estate_privileges = {
 				estate = estate_church
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_church
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_church
+			    loyalty = 50
 			}
 		}
 	}
@@ -2140,7 +2228,18 @@ estate_church_heir_shrine = {
 			NOT = { has_estate_privilege = estate_church_religious_state }
 			num_of_estate_privileges = {
 				estate = estate_church
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_church
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_church
+			    loyalty = 50
 			}
 		}
 	}
@@ -2276,7 +2375,18 @@ estate_church_scholar_connections = {
 			NOT = { has_estate_privilege = estate_church_religious_state }
 			num_of_estate_privileges = {
 				estate = estate_church
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_church
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_church
+			    loyalty = 50
 			}
 		}
 	}
@@ -2327,7 +2437,18 @@ estate_church_integrated_school = {
 			NOT = { has_estate_privilege = estate_church_religious_state }
 			num_of_estate_privileges = {
 				estate = estate_church
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_church
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_church
+			    loyalty = 50
 			}
 		}
 	}
@@ -2383,7 +2504,18 @@ estate_church_yakobs_churches = {
 			NOT = { has_estate_privilege = estate_church_religious_state }
 			num_of_estate_privileges = {
 				estate = estate_church
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_church
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_church
+			    loyalty = 50
 			}
 		}
 	}
@@ -2651,7 +2783,7 @@ estate_church_development_of_temples = {
 			limit = {
 				OR = {
 					has_owner_religion = yes
-					has_owner_harmonized_religion = yes
+					has_owner_harmonized_religion_fixed = yes
 					has_owner_secondary_religion = yes
 				}
 				has_tax_building_trigger = yes
@@ -2850,7 +2982,18 @@ estate_church_clerical_education = {
 			NOT = { has_estate_privilege = estate_church_religious_state }
 			num_of_estate_privileges = {
 				estate = estate_church
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_church
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_church
+			    loyalty = 50
 			}
 		}
 	}
@@ -2898,7 +3041,18 @@ estate_church_religious_delegation = {
 			NOT = { has_estate_privilege = estate_church_religious_state }
 			num_of_estate_privileges = {
 				estate = estate_church
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_church
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_church
+			    loyalty = 50
 			}
 		}
 	}
@@ -2946,7 +3100,18 @@ estate_church_institutionalized_clergy = {
 			NOT = { has_estate_privilege = estate_church_religious_state }
 			num_of_estate_privileges = {
 				estate = estate_church
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_church
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_church
+			    loyalty = 50
 			}
 		}
 	}
@@ -3012,7 +3177,18 @@ estate_church_donation_right = {
 			NOT = { has_estate_privilege = estate_church_religious_state }
 			num_of_estate_privileges = {
 				estate = estate_church
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_church
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_church
+			    loyalty = 50
 			}
 		}
 	}

--- a/common/estate_privileges/02_noble_privileges.txt
+++ b/common/estate_privileges/02_noble_privileges.txt
@@ -202,7 +202,18 @@ estate_nobles_land_rights = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -430,7 +441,18 @@ estate_nobles_levies = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -475,7 +497,18 @@ estate_nobles_advisors = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -510,7 +543,18 @@ estate_nobles_right_of_counsel = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -605,7 +649,18 @@ estate_nobles_french_strong_duchies = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -675,7 +730,18 @@ estate_nobles_supremacy_over_crown = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -1137,7 +1203,18 @@ estate_nobles_junker_primacy = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -1229,7 +1306,18 @@ estate_nobles_strong_duchies = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -1512,7 +1600,18 @@ estate_nobles_better_integration = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -1636,7 +1735,18 @@ estate_nobles_cawa_peace_keepers = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -1708,7 +1818,18 @@ estate_nobles_cawa_offensive_fighters = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -1760,7 +1881,18 @@ estate_nobles_grant_power_to_the_bashorun = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -1829,7 +1961,18 @@ estate_nobles_carolean_march = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -1898,7 +2041,18 @@ estate_nobles_carolean_charge = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -1937,7 +2091,18 @@ estate_nobles_leidang_conscription = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -2149,7 +2314,18 @@ estate_nobles_religious_conscription = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -2408,7 +2584,18 @@ estate_nobles_sponsor_hussars = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -2440,7 +2627,18 @@ estate_nobles_mansabdari_cav_maintenance = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -2471,7 +2669,18 @@ estate_nobles_mansabdari_military_service = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -2494,7 +2703,18 @@ estate_nobles_mansabdari_royal_rule = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -2529,7 +2749,18 @@ estate_nobles_rynda = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -2562,7 +2793,18 @@ estate_nobles_landed_army = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -2705,7 +2947,18 @@ estate_nobles_early_serfdom = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -2792,7 +3045,18 @@ estate_nobles_legalized_serfdom = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -2878,7 +3142,18 @@ estate_nobles_total_serfdom = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -2960,7 +3235,18 @@ estate_nobles_restricted_serfdom = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -3043,7 +3329,18 @@ estate_nobles_devastating_serfdom = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -3131,7 +3428,18 @@ estate_nobles_increased_peasant_freedom = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -3212,7 +3520,18 @@ estate_nobles_peasant_liberation = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -3270,7 +3589,18 @@ estate_nobles_factionalist_nobility = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}#TODO
@@ -3315,7 +3645,18 @@ estate_nobles_consolidated_noble_contracts = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -3361,7 +3702,18 @@ estate_nobles_english_villeinage = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -3402,7 +3754,18 @@ estate_nobles_english_copyhold_tenure = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
@@ -3493,6 +3856,7 @@ estate_nobles_development_of_castles = {
 		factor = 0
 	}
 }
+
 estate_nobles_statesman_servitude = {
 	icon = privilege_diplomat
 	loyalty = 0.0
@@ -3531,6 +3895,7 @@ estate_nobles_statesman_servitude = {
 		factor = 0
 	}
 }
+
 estate_nobles_royal_court_tasks = {
 	icon = privilege_build_jain_temple
 	loyalty = 0.0
@@ -3613,6 +3978,7 @@ estate_nobles_royal_court_tasks = {
 		factor = 0
 	}
 }
+
 estate_nobles_diet_right = {
 	icon = privilege_government
 	loyalty = 0.0
@@ -3658,11 +4024,23 @@ estate_nobles_diet_right = {
 			NOT = { has_estate_privilege = estate_nobles_nobility_primacy }
 			num_of_estate_privileges = {
 				estate = estate_nobles
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_nobles
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_nobles
+			    loyalty = 50
 			}
 		}
 	}
 }
+
 estate_nobles_force_conscription = {
 	icon = privilege_land_force_limit
 	loyalty = 0
@@ -3699,6 +4077,7 @@ estate_nobles_force_conscription = {
 		factor = 0
 	}
 }
+
 estate_nobles_noble_officer_right = {
 	icon = privilege_army_tradition
 	loyalty = 0.0
@@ -3745,6 +4124,7 @@ estate_nobles_noble_officer_right = {
 		factor = 0
 	}
 }
+
 estate_nobles_expedition_rights = {
 	icon = privilege_conquistador
 	loyalty = 0.0

--- a/common/estate_privileges/03_burgher_privileges.txt
+++ b/common/estate_privileges/03_burgher_privileges.txt
@@ -202,7 +202,18 @@ estate_burghers_land_rights = {
 			NOT = { has_estate_privilege = estate_burghers_land_of_commerce }
 			num_of_estate_privileges = {
 				estate = estate_burghers
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_burghers
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_burghers
+			    loyalty = 50
 			}
 		}
 	}
@@ -388,7 +399,18 @@ estate_burghers_commercial_board_of_advice = {
 			NOT = { has_estate_privilege = estate_burghers_land_of_commerce }
 			num_of_estate_privileges = {
 				estate = estate_burghers
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_burghers
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_burghers
+			    loyalty = 50
 			}
 		}
 	}
@@ -485,7 +507,18 @@ estate_burghers_new_world_charter = {
 			NOT = { has_estate_privilege = estate_burghers_land_of_commerce }
 			num_of_estate_privileges = {
 				estate = estate_burghers
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_burghers
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_burghers
+			    loyalty = 50
 			}
 		}
 	}
@@ -592,7 +625,18 @@ estate_burghers_free_enterprise = {
 			NOT = { has_estate_privilege = estate_burghers_land_of_commerce }
 			num_of_estate_privileges = {
 				estate = estate_burghers
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_burghers
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_burghers
+			    loyalty = 50
 			}
 		}
 	}
@@ -1496,7 +1540,18 @@ estate_burghers_private_trade_fleets = {
 			NOT = { has_estate_privilege = estate_burghers_land_of_commerce }
 			num_of_estate_privileges = {
 				estate = estate_burghers
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_burghers
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_burghers
+			    loyalty = 50
 			}
 		}
 	}
@@ -1547,7 +1602,18 @@ estate_burghers_prussian_confederation = {
 			NOT = { has_estate_privilege = estate_burghers_land_of_commerce }
 			num_of_estate_privileges = {
 				estate = estate_burghers
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_burghers
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_burghers
+			    loyalty = 50
 			}
 		}
 	}
@@ -1770,7 +1836,18 @@ estate_burghers_orang_laut_alliances = {
 			NOT = { has_estate_privilege = estate_burghers_land_of_commerce }
 			num_of_estate_privileges = {
 				estate = estate_burghers
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_burghers
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_burghers
+			    loyalty = 50
 			}
 		}
 	}
@@ -1883,7 +1960,18 @@ estate_burghers_hydraulic_rights = {
 			NOT = { has_estate_privilege = estate_burghers_land_of_commerce }
 			num_of_estate_privileges = {
 				estate = estate_burghers
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_burghers
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_burghers
+			    loyalty = 50
 			}
 		}
 	}
@@ -1980,7 +2068,18 @@ estate_burghers_control_over_the_mint = {
 			NOT = { has_estate_privilege = estate_burghers_land_of_commerce }
 			num_of_estate_privileges = {
 				estate = estate_burghers
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_burghers
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_burghers
+			    loyalty = 50
 			}
 		}
 	}
@@ -2066,7 +2165,18 @@ estate_burghers_forest_expansion = {
 			NOT = { has_estate_privilege = estate_burghers_land_of_commerce }
 			num_of_estate_privileges = {
 				estate = estate_burghers
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_burghers
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_burghers
+			    loyalty = 50
 			}
 		}
 	}
@@ -2165,7 +2275,18 @@ estate_burghers_mountain_expansion = {
 			NOT = { has_estate_privilege = estate_burghers_land_of_commerce }
 			num_of_estate_privileges = {
 				estate = estate_burghers
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_burghers
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_burghers
+			    loyalty = 50
 			}
 		}
 	}
@@ -2695,7 +2816,18 @@ estate_burghers_expanded_monopoly_rights = {
 			NOT = { has_estate_privilege = estate_burghers_land_of_commerce }
 			num_of_estate_privileges = {
 				estate = estate_burghers
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_burghers
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_burghers
+			    loyalty = 50
 			}
 		}
 	}
@@ -2873,7 +3005,18 @@ estate_burghers_promote_burgher_bookkeeping = {
 			NOT = { has_estate_privilege = estate_burghers_land_of_commerce }
 			num_of_estate_privileges = {
 				estate = estate_burghers
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_burghers
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_burghers
+			    loyalty = 50
 			}
 		}
 	}

--- a/common/estate_privileges/07_jain_privileges.txt
+++ b/common/estate_privileges/07_jain_privileges.txt
@@ -188,7 +188,18 @@ estate_jains_land_rights = {
 			NOT = { has_estate_privilege = estate_jains_diplomacy }
 			num_of_estate_privileges = {
 				estate = estate_jains
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_jains
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_jains
+			    loyalty = 50
 			}
 		}
 	}
@@ -274,7 +285,18 @@ estate_jains_clerical_class = {
 			NOT = { has_estate_privilege = estate_jains_diplomacy }
 			num_of_estate_privileges = {
 				estate = estate_jains
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_jains
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_jains
+			    loyalty = 50
 			}
 		}
 	}
@@ -378,7 +400,18 @@ estate_jains_grant_liberties = {
 			NOT = { has_estate_privilege = estate_jains_diplomacy }
 			num_of_estate_privileges = {
 				estate = estate_jains
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_jains
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_jains
+			    loyalty = 50
 			}
 		}
 	}
@@ -418,7 +451,18 @@ estate_jains_land_trade_rights = {
 			NOT = { has_estate_privilege = estate_jains_diplomacy }
 			num_of_estate_privileges = {
 				estate = estate_jains
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_jains
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_jains
+			    loyalty = 50
 			}
 		}
 	}
@@ -1107,7 +1151,18 @@ estate_jains_control_over_monetary_policy = {
 			NOT = { has_estate_privilege = estate_jains_diplomacy }
 			num_of_estate_privileges = {
 				estate = estate_jains
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_jains
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_jains
+			    loyalty = 50
 			}
 		}
 	}
@@ -1149,7 +1204,18 @@ estate_jains_private_trade_fleets = {
 			NOT = { has_estate_privilege = estate_jains_diplomacy }
 			num_of_estate_privileges = {
 				estate = estate_jains
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_jains
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_jains
+			    loyalty = 50
 			}
 		}
 	}
@@ -1360,7 +1426,18 @@ estate_jains_patronize_jain_familiy = {
 			NOT = { has_estate_privilege = estate_jains_diplomacy }
 			num_of_estate_privileges = {
 				estate = estate_jains
-				value = 5
+				value = 6
+			}
+			crown_land_share = 30
+			NOT = {
+				estate_influence = {
+					estate = estate_jains
+					influence = 95
+				}
+			}
+			estate_loyalty = {
+			    estate = estate_jains
+			    loyalty = 50
 			}
 		}
 	}


### PR DESCRIPTION
The AI can get stuck in an endless loop of granting and revoking privileges to estates, which generates a non-stop stream of rebels.

The issue has to do with the bit of logic that tells the AI to revoke a privilege when an estate already has a full set, to make space for a mana-generating one. The issue is that it revokes even when it does not have the crown land it needs to grant the mana-generating privilege, and so it then just re-adds the privilege it had revoked, which then gets revoked again, and so on.

Here I made it so that it only revokes in such cases when can actually replace it with a mana-generating one.

Incidentally also fixed a bug where the rajputs were checking for brahmin privileges.

The default number of max privileges in Vanilla (not changed by the mod) is 6 now, not 5. Adjusted the logic accordingly here.