### PR TITLE
Make gentler peace terms cheaper

### DIFF
--- a/common/defines/gentler_peace_terms_are_cheaper.lua
+++ b/common/defines/gentler_peace_terms_are_cheaper.lua
@@ -1,0 +1,7 @@
+NDefines.NDiplomacy.PEACE_COST_RETURN_CORE = 0.5 -- 0.8 in vanilla. returning a core should be significantly cheaper than demanding the concession of a random province.
+NDefines.NDiplomacy.PEACE_COST_REVOKE_CORE = 0.25 -- 0.4 in vanilla. set to half of returning a core.
+NDefines.NDiplomacy.PEACE_COST_RELEASE_ANNEXED = 0.6 -- 0.8 in vanilla. releasing should be cheaper than demanding the concession of the province.
+NDefines.NDiplomacy.PEACE_COST_RELEASE_VASSAL = 0.3 -- 0.4 in vanilla. set to half of releasing annexed
+NDefines.NDiplomacy.PEACE_COST_CONVERSION = 0.3 -- 0.8 in vanilla. conversion should definitely be a lot cheaper than demanding full annexation.
+NDefines.NDiplomacy.PEACE_COST_ENFORCED_FLEET_BASING_RIGHTS = 10 -- 25 in vanilla. the victor still has to pay for it lol
+NDefines.NDiplomacy.PEACE_COST_ENFORCED_MILITARY_ACCESS = 5 -- 15 in vanilla. it is difficult to think of a situation where this would be preferable as an option to money or anything else really


### PR DESCRIPTION
In Vanilla, many of the gentler or more justified peace terms, such as core return, have the same cost as annexing a random province. Even worse, admin efficiency reduces the cost, in war score, of unjustified territorial expansion, while terms with better justifications, such as core return or release, remain expensive in Vanilla. Gentler terms that the victor doesn't directly benefit from are changed to have a significantly lower cost here. This indirectly buffs Buddhists, who will have an easier time maintaining Karma through such terms.