### PR TITLE
No institution growth from dev clicks

### DIFF
--- a/common/defines/no_institutions_from_dev.lua
+++ b/common/defines/no_institutions_from_dev.lua
@@ -1,0 +1,3 @@
+NDefines.NCountry.INSTITUTION_BONUS_FROM_IMP_DEVELOPMENT = 0 -- 5 in vanilla.
+NDefines.NCountry.INSTITUTION_CAP_IMP_DEVELOPMENT = 0 -- 10 in vanilla.
+NDefines.NCountry.INSTITUTION_BASE_IMP_DEVELOPMENT = 0 -- 30 in vanilla.

--- a/decisions/dev_decisions.txt
+++ b/decisions/dev_decisions.txt
@@ -40,165 +40,166 @@ country_decisions = {
 			factor = 0
 		}
 	}
-	
-	spawn_click = {
-		major = yes
-		potential = {
-			has_global_flag = ai_dev_click
-			ai = yes
-			OR = {
-				had_country_flag = { flag = institution_flag	days = 365 }
-				NOT = { has_country_flag = institution_flag }
-			}
-			is_lacking_institutions = yes
-			is_at_war = no
-			primitives = no
-			OR = {
-				is_subject_of_type = tributary_state
-				is_subject = no
-			}
-			num_of_cities = 5
-			OR = {
-				NOT = { has_dlc = "Rights of Man" }
-				ruler_has_personality = free_thinker_personality
-				ruler_has_personality = scholar_personality
-				ruler_has_personality = entrepreneur_personality
-				ruler_has_personality = industrious_personality
-			}
-			
-			all_owned_province = {
-				OR = {
-					NOT = { is_state_core = ROOT }
-					NOT = { current_institution_growth = 0.5 }
-				}
-			}
-			
-			any_owned_province = {
-				is_state_core = ROOT
-				development = 5
-				NOT = { development = 28 }
-				NOT = { has_terrain = glacier }
-				NOT = { has_terrain = desert }
-				NOT = { has_climate = arctic }
-			}
-		}
-		allow = {
-			variable_arithmetic_trigger = {
-				export_to_variable = { variable_name = admPower 	value = trigger_value:adm_power }
-				export_to_variable = { variable_name = dipPower 	value = trigger_value:dip_power }
-				export_to_variable = { variable_name = milPower 	value = trigger_value:mil_power }
-				
-				change_variable = {
-					which = admPower
-					which = dipPower
-				}
-				change_variable = {
-					which = admPower
-					which = milPower
-				}
-				check_variable = {
-					which = admPower
-					value = 2300
-				}
-			}
-		}
-		effect = {
-			hidden_effect = {
-				set_country_flag = institution_flag
-				log = "[Root.GetName] trying to spawn institution"
-				
-				if = {
-					limit = {
-						NOT = { has_institution = feudalism }
-					}
-					spawn_institution = {
-						institution = feudalism
-					}
-					event_target:base_target = {
-						log = "[Root.GetName] spawned feudalism in [This.GetName]"
-					}
-				}
-				else_if = {
-					limit = {
-						NOT = { has_institution = renaissance }
-					}
-					spawn_institution = {
-						institution = renaissance
-					}
-					event_target:base_target = {
-						log = "[Root.GetName] spawned renaissance in [This.GetName]"
-					}
-				}
-				else_if = {
-					limit = {
-						NOT = { has_institution = new_world_i }
-					}
-					spawn_institution = {
-						institution = new_world_i
-					}
-					event_target:base_target = {
-						log = "[Root.GetName] spawned new_world_i in [This.GetName]"
-					}
-				}
-				else_if = {
-					limit = {
-						NOT = { has_institution = printing_press }
-					}
-					spawn_institution = {
-						institution = printing_press
-					}
-					event_target:base_target = {
-						log = "[Root.GetName] spawned printing_press in [This.GetName]"
-					}
-				}
-				else_if = {
-					limit = {
-						NOT = { has_institution = global_trade }
-					}
-					spawn_institution = {
-						institution = global_trade
-					}
-					event_target:base_target = {
-						log = "[Root.GetName] spawned global_trade in [This.GetName]"
-					}
-				}
-				else_if = {
-					limit = {
-						NOT = { has_institution = manufactories }
-					}
-					spawn_institution = {
-						institution = manufactories
-					}
-					event_target:base_target = {
-						log = "[Root.GetName] spawned manufactories in [This.GetName]"
-					}
-				}
-				else_if = {
-					limit = {
-						NOT = { has_institution = enlightenment }
-					}
-					spawn_institution = {
-						institution = enlightenment
-					}
-					event_target:base_target = {
-						log = "[Root.GetName] spawned enlightenment in [This.GetName]"
-					}
-				}
-				else_if = {
-					limit = {
-						NOT = { has_institution = industrialization }
-					}
-					spawn_institution = {
-						institution = industrialization
-					}
-					event_target:base_target = {
-						log = "[Root.GetName] spawned industrialization in [This.GetName]"
-					}
-				}
-			}
-		}
-		ai_will_do = {
-			factor = 1000
-		}
-	}
 }
+
+## Disable AI trying to spawn Institutions through dev clicks, as dev clicks no longer spawn institutions.
+#	spawn_click = {
+#		major = yes
+#		potential = {
+#			has_global_flag = ai_dev_click
+#			ai = yes
+#			OR = {
+#				had_country_flag = { flag = institution_flag	days = 365 }
+#				NOT = { has_country_flag = institution_flag }
+#			}
+#			is_lacking_institutions = yes
+#			is_at_war = no
+#			primitives = no
+#			OR = {
+#				is_subject_of_type = tributary_state
+#				is_subject = no
+#			}
+#			num_of_cities = 5
+#			OR = {
+#				NOT = { has_dlc = "Rights of Man" }
+#				ruler_has_personality = free_thinker_personality
+#				ruler_has_personality = scholar_personality
+#				ruler_has_personality = entrepreneur_personality
+#				ruler_has_personality = industrious_personality
+#			}
+#			
+#			all_owned_province = {
+#				OR = {
+#					NOT = { is_state_core = ROOT }
+#					NOT = { current_institution_growth = 0.5 }
+#				}
+#			}
+#			
+#			any_owned_province = {
+#				is_state_core = ROOT
+#				development = 5
+#				NOT = { development = 28 }
+#				NOT = { has_terrain = glacier }
+#				NOT = { has_terrain = desert }
+#				NOT = { has_climate = arctic }
+#			}
+#		}
+#		allow = {
+#			variable_arithmetic_trigger = {
+#				export_to_variable = { variable_name = admPower 	value = trigger_value:adm_power }
+#				export_to_variable = { variable_name = dipPower 	value = trigger_value:dip_power }
+#				export_to_variable = { variable_name = milPower 	value = trigger_value:mil_power }
+#				
+#				change_variable = {
+#					which = admPower
+#					which = dipPower
+#				}
+#				change_variable = {
+#					which = admPower
+#					which = milPower
+#				}
+#				check_variable = {
+#					which = admPower
+#					value = 2300
+#				}
+#			}
+#		}
+#		effect = {
+#			hidden_effect = {
+#				set_country_flag = institution_flag
+#				log = "[Root.GetName] trying to spawn institution"
+#				
+#				if = {
+#					limit = {
+#						NOT = { has_institution = feudalism }
+#					}
+#					spawn_institution = {
+#						institution = feudalism
+#					}
+#					event_target:base_target = {
+#						log = "[Root.GetName] spawned feudalism in [This.GetName]"
+#					}
+#				}
+#				else_if = {
+#					limit = {
+#						NOT = { has_institution = renaissance }
+#					}
+#					spawn_institution = {
+#						institution = renaissance
+#					}
+#					event_target:base_target = {
+#						log = "[Root.GetName] spawned renaissance in [This.GetName]"
+#					}
+#				}
+#				else_if = {
+#					limit = {
+#						NOT = { has_institution = new_world_i }
+#					}
+#					spawn_institution = {
+#						institution = new_world_i
+#					}
+#					event_target:base_target = {
+#						log = "[Root.GetName] spawned new_world_i in [This.GetName]"
+#					}
+#				}
+#				else_if = {
+#					limit = {
+#						NOT = { has_institution = printing_press }
+#					}
+#					spawn_institution = {
+#						institution = printing_press
+#					}
+#					event_target:base_target = {
+#						log = "[Root.GetName] spawned printing_press in [This.GetName]"
+#					}
+#				}
+#				else_if = {
+#					limit = {
+#						NOT = { has_institution = global_trade }
+#					}
+#					spawn_institution = {
+#						institution = global_trade
+#					}
+#					event_target:base_target = {
+#						log = "[Root.GetName] spawned global_trade in [This.GetName]"
+#					}
+#				}
+#				else_if = {
+#					limit = {
+#						NOT = { has_institution = manufactories }
+#					}
+#					spawn_institution = {
+#						institution = manufactories
+#					}
+#					event_target:base_target = {
+#						log = "[Root.GetName] spawned manufactories in [This.GetName]"
+#					}
+#				}
+#				else_if = {
+#					limit = {
+#						NOT = { has_institution = enlightenment }
+#					}
+#					spawn_institution = {
+#						institution = enlightenment
+#					}
+#					event_target:base_target = {
+#						log = "[Root.GetName] spawned enlightenment in [This.GetName]"
+#					}
+#				}
+#				else_if = {
+#					limit = {
+#						NOT = { has_institution = industrialization }
+#					}
+#					spawn_institution = {
+#						institution = industrialization
+#					}
+#					event_target:base_target = {
+#						log = "[Root.GetName] spawned industrialization in [This.GetName]"
+#					}
+#				}
+#			}
+#		}
+#		ai_will_do = {
+#			factor = 1000
+#		}
+#	}


### PR DESCRIPTION
A small landlocked Tibet without allies should not be the first to develop the institute of Colonization in Asia, just because it saved up a lot of mana.

This PR disables instantaneous institution growth from clicking dev buttons. Natural spread (from neighboring provinces, etc) is not affected by this change, and province development still scales the rate of natural spread.

This has the effect of making tech levels, at least in the early game, more varied across the world. It also makes things harder for players starting outside of Europe, who can no longer rely on strategic use of mana to make institutions magically appear.

This results, overall, in a somewhat more historical and less uniform world, and a slightly increased difficulty.